### PR TITLE
Add exercises from the Exercism.io project

### DIFF
--- a/exercises/LICENSE
+++ b/exercises/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Exercism, Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/exercises/README
+++ b/exercises/README
@@ -1,0 +1,6 @@
+These exercises come from the Exercisim.io project
+
+https://github.com/exercism/ruby
+
+Exercisim exercises are MIT licensed.
+

--- a/exercises/accumulate/README.md
+++ b/exercises/accumulate/README.md
@@ -1,0 +1,74 @@
+# Accumulate
+
+Implement the `accumulate` operation, which, given a collection and an
+operation to perform on each element of the collection, returns a new
+collection containing the result of applying that operation to each element of
+the input collection.
+
+Given the collection of numbers:
+
+- 1, 2, 3, 4, 5
+
+And the operation:
+
+- square a number (`x => x * x`)
+
+Your code should be able to produce the collection of squares:
+
+- 1, 4, 9, 16, 25
+
+Check out the test suite to see the expected function signature.
+
+## Restrictions
+
+Keep your hands off that collect/map/fmap/whatchamacallit functionality
+provided by your standard library!
+Solve this one yourself using other basic tools instead.
+
+## Advanced
+
+It is typical to call [#to_enum](http://ruby-doc.org/core-2.3.1/Object.html#method-i-to_enum) when defining methods for a generic Enumerable, in case no block is passed.
+
+Here is an additional test you could add:
+
+```ruby
+def test_accumulate_when_block_is_deferred
+  skip
+  accumulate_enumerator = [1, 2, 3].accumulate
+  accumulated_result = accumulate_enumerator.each do |number|
+    number * number
+  end
+  assert_equal [1, 4, 9], accumulated_result
+end
+```
+
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby accumulate_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride accumulate_test.rb
+
+
+## Source
+
+Conversation with James Edward Gray II [https://twitter.com/jeg2](https://twitter.com/jeg2)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/accumulate/accumulate_test.rb
+++ b/exercises/accumulate/accumulate_test.rb
@@ -1,0 +1,67 @@
+require 'minitest/autorun'
+require_relative 'accumulate'
+
+class ArrayTest < Minitest::Test
+  def test_empty_accumulation
+    assert_equal [], [].accumulate { |e| e * e }
+  end
+
+  def test_accumulate_squares
+    skip
+    result = [1, 2, 3].accumulate do |number|
+      number * number
+    end
+    assert_equal [1, 4, 9], result
+  end
+
+  def test_accumulate_upcases
+    skip
+    result = %w(hello world).accumulate(&:upcase)
+    assert_equal %w(HELLO WORLD), result
+  end
+
+  def test_accumulate_reversed_strings
+    skip
+    result = %w(the quick brown fox etc).accumulate(&:reverse)
+    assert_equal %w(eht kciuq nworb xof cte), result
+  end
+
+  def test_accumulate_recursively
+    skip
+    result = %w(a b c).accumulate do |char|
+      %w(1 2 3).accumulate do |digit|
+        "#{char}#{digit}"
+      end
+    end
+    assert_equal [%w(a1 a2 a3), %w(b1 b2 b3), %w(c1 c2 c3)], result
+  end
+
+  def test_do_not_change_in_place
+    skip
+    original = [1, 2, 3]
+    copy = original.dup
+    original.accumulate { |n| n * n }
+    assert_equal copy, original
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module.
+  #  In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/acronym/README.md
+++ b/exercises/acronym/README.md
@@ -1,0 +1,38 @@
+# Acronym
+
+Convert a phrase to its acronym.
+
+Techies love their TLA (Three Letter Acronyms)!
+
+Help generate some jargon by writing a program that converts a long name
+like Portable Network Graphics to its acronym (PNG).
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby acronym_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride acronym_test.rb
+
+
+## Source
+
+Julien Vanier [https://github.com/monkbroc](https://github.com/monkbroc)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/acronym/acronym_test.rb
+++ b/exercises/acronym/acronym_test.rb
@@ -1,0 +1,57 @@
+require 'minitest/autorun'
+require_relative 'acronym'
+
+# Common test data version: 1.1.0 cae7ae1
+class AcronymTest < Minitest::Test
+  def test_basic
+    # skip
+    assert_equal "PNG", Acronym.abbreviate('Portable Network Graphics')
+  end
+
+  def test_lowercase_words
+    skip
+    assert_equal "ROR", Acronym.abbreviate('Ruby on Rails')
+  end
+
+  def test_punctuation
+    skip
+    assert_equal "FIFO", Acronym.abbreviate('First In, First Out')
+  end
+
+  def test_all_caps_words
+    skip
+    assert_equal "PHP", Acronym.abbreviate('PHP: Hypertext Preprocessor')
+  end
+
+  def test_non_acronym_all_caps_word
+    skip
+    assert_equal "GIMP", Acronym.abbreviate('GNU Image Manipulation Program')
+  end
+
+  def test_hyphenated
+    skip
+    assert_equal "CMOS", Acronym.abbreviate('Complementary metal-oxide semiconductor')
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 4, BookKeeping::VERSION
+  end
+end

--- a/exercises/all-your-base/README.md
+++ b/exercises/all-your-base/README.md
@@ -1,0 +1,58 @@
+# All Your Base
+
+Convert a number, represented as a sequence of digits in one base, to any other base.
+
+Implement general base conversion. Given a number in base **a**,
+represented as a sequence of digits, convert it to base **b**.
+
+## Note
+
+- Try to implement the conversion yourself.
+  Do not use something else to perform the conversion for you.
+
+## About [Positional Notation](https://en.wikipedia.org/wiki/Positional_notation)
+
+In positional notation, a number in base **b** can be understood as a linear
+combination of powers of **b**.
+
+The number 42, *in base 10*, means:
+
+(4 * 10^1) + (2 * 10^0)
+
+The number 101010, *in base 2*, means:
+
+(1 * 2^5) + (0 * 2^4) + (1 * 2^3) + (0 * 2^2) + (1 * 2^1) + (0 * 2^0)
+
+The number 1120, *in base 3*, means:
+
+(1 * 3^3) + (1 * 3^2) + (2 * 3^1) + (0 * 3^0)
+
+I think you got the idea!
+
+*Yes. Those three numbers above are exactly the same. Congratulations!*
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby all_your_base_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride all_your_base_test.rb
+
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/all-your-base/all_your_base_test.rb
+++ b/exercises/all-your-base/all_your_base_test.rb
@@ -1,0 +1,294 @@
+require 'minitest/autorun'
+require_relative 'all_your_base'
+
+# Common test data version: 1.1.0 c4d8d95
+class AllYourBaseTest < Minitest::Test
+  def test_single_bit_one_to_decimal
+    # skip
+    digits = [1]
+    input_base = 2
+    output_base = 10
+    expected = [1]
+
+    converted = BaseConverter.convert(input_base, digits, output_base)
+
+    assert_equal expected, converted,
+                 "Input base: #{input_base}, output base #{output_base}. " \
+                 "Expected #{expected} but got #{converted}."
+  end
+
+  def test_binary_to_single_decimal
+    skip
+    digits = [1, 0, 1]
+    input_base = 2
+    output_base = 10
+    expected = [5]
+
+    converted = BaseConverter.convert(input_base, digits, output_base)
+
+    assert_equal expected, converted,
+                 "Input base: #{input_base}, output base #{output_base}. " \
+                 "Expected #{expected} but got #{converted}."
+  end
+
+  def test_single_decimal_to_binary
+    skip
+    digits = [5]
+    input_base = 10
+    output_base = 2
+    expected = [1, 0, 1]
+
+    converted = BaseConverter.convert(input_base, digits, output_base)
+
+    assert_equal expected, converted,
+                 "Input base: #{input_base}, output base #{output_base}. " \
+                 "Expected #{expected} but got #{converted}."
+  end
+
+  def test_binary_to_multiple_decimal
+    skip
+    digits = [1, 0, 1, 0, 1, 0]
+    input_base = 2
+    output_base = 10
+    expected = [4, 2]
+
+    converted = BaseConverter.convert(input_base, digits, output_base)
+
+    assert_equal expected, converted,
+                 "Input base: #{input_base}, output base #{output_base}. " \
+                 "Expected #{expected} but got #{converted}."
+  end
+
+  def test_decimal_to_binary
+    skip
+    digits = [4, 2]
+    input_base = 10
+    output_base = 2
+    expected = [1, 0, 1, 0, 1, 0]
+
+    converted = BaseConverter.convert(input_base, digits, output_base)
+
+    assert_equal expected, converted,
+                 "Input base: #{input_base}, output base #{output_base}. " \
+                 "Expected #{expected} but got #{converted}."
+  end
+
+  def test_trinary_to_hexadecimal
+    skip
+    digits = [1, 1, 2, 0]
+    input_base = 3
+    output_base = 16
+    expected = [2, 10]
+
+    converted = BaseConverter.convert(input_base, digits, output_base)
+
+    assert_equal expected, converted,
+                 "Input base: #{input_base}, output base #{output_base}. " \
+                 "Expected #{expected} but got #{converted}."
+  end
+
+  def test_hexadecimal_to_trinary
+    skip
+    digits = [2, 10]
+    input_base = 16
+    output_base = 3
+    expected = [1, 1, 2, 0]
+
+    converted = BaseConverter.convert(input_base, digits, output_base)
+
+    assert_equal expected, converted,
+                 "Input base: #{input_base}, output base #{output_base}. " \
+                 "Expected #{expected} but got #{converted}."
+  end
+
+  def test_15_bit_integer
+    skip
+    digits = [3, 46, 60]
+    input_base = 97
+    output_base = 73
+    expected = [6, 10, 45]
+
+    converted = BaseConverter.convert(input_base, digits, output_base)
+
+    assert_equal expected, converted,
+                 "Input base: #{input_base}, output base #{output_base}. " \
+                 "Expected #{expected} but got #{converted}."
+  end
+
+  def test_empty_list
+    skip
+    digits = []
+    input_base = 2
+    output_base = 10
+    expected = []
+
+    converted = BaseConverter.convert(input_base, digits, output_base)
+
+    assert_equal expected, converted,
+                 "Input base: #{input_base}, output base #{output_base}. " \
+                 "Expected #{expected} but got #{converted}."
+  end
+
+  def test_single_zero
+    skip
+    digits = [0]
+    input_base = 10
+    output_base = 2
+    expected = [0]
+
+    converted = BaseConverter.convert(input_base, digits, output_base)
+
+    assert_equal expected, converted,
+                 "Input base: #{input_base}, output base #{output_base}. " \
+                 "Expected #{expected} but got #{converted}."
+  end
+
+  def test_multiple_zeros
+    skip
+    digits = [0, 0, 0]
+    input_base = 10
+    output_base = 2
+    expected = [0]
+
+    converted = BaseConverter.convert(input_base, digits, output_base)
+
+    assert_equal expected, converted,
+                 "Input base: #{input_base}, output base #{output_base}. " \
+                 "Expected #{expected} but got #{converted}."
+  end
+
+  def test_leading_zeros
+    skip
+    digits = [0, 6, 0]
+    input_base = 7
+    output_base = 10
+    expected = [4, 2]
+
+    converted = BaseConverter.convert(input_base, digits, output_base)
+
+    assert_equal expected, converted,
+                 "Input base: #{input_base}, output base #{output_base}. " \
+                 "Expected #{expected} but got #{converted}."
+  end
+
+  def test_first_base_is_one
+    skip
+    digits = []
+    input_base = 1
+    output_base = 10
+
+    assert_raises ArgumentError do
+      BaseConverter.convert(input_base, digits, output_base)
+    end
+  end
+
+  def test_first_base_is_zero
+    skip
+    digits = []
+    input_base = 0
+    output_base = 10
+
+    assert_raises ArgumentError do
+      BaseConverter.convert(input_base, digits, output_base)
+    end
+  end
+
+  def test_first_base_is_negative
+    skip
+    digits = [1]
+    input_base = -2
+    output_base = 10
+
+    assert_raises ArgumentError do
+      BaseConverter.convert(input_base, digits, output_base)
+    end
+  end
+
+  def test_negative_digit
+    skip
+    digits = [1, -1, 1, 0, 1, 0]
+    input_base = 2
+    output_base = 10
+
+    assert_raises ArgumentError do
+      BaseConverter.convert(input_base, digits, output_base)
+    end
+  end
+
+  def test_invalid_positive_digit
+    skip
+    digits = [1, 2, 1, 0, 1, 0]
+    input_base = 2
+    output_base = 10
+
+    assert_raises ArgumentError do
+      BaseConverter.convert(input_base, digits, output_base)
+    end
+  end
+
+  def test_second_base_is_one
+    skip
+    digits = [1, 0, 1, 0, 1, 0]
+    input_base = 2
+    output_base = 1
+
+    assert_raises ArgumentError do
+      BaseConverter.convert(input_base, digits, output_base)
+    end
+  end
+
+  def test_second_base_is_zero
+    skip
+    digits = [7]
+    input_base = 10
+    output_base = 0
+
+    assert_raises ArgumentError do
+      BaseConverter.convert(input_base, digits, output_base)
+    end
+  end
+
+  def test_second_base_is_negative
+    skip
+    digits = [1]
+    input_base = 2
+    output_base = -7
+
+    assert_raises ArgumentError do
+      BaseConverter.convert(input_base, digits, output_base)
+    end
+  end
+
+  def test_both_bases_are_negative
+    skip
+    digits = [1]
+    input_base = -2
+    output_base = -7
+
+    assert_raises ArgumentError do
+      BaseConverter.convert(input_base, digits, output_base)
+    end
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 2, BookKeeping::VERSION
+  end
+end

--- a/exercises/allergies/README.md
+++ b/exercises/allergies/README.md
@@ -1,0 +1,60 @@
+# Allergies
+
+Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.
+
+An allergy test produces a single numeric score which contains the
+information about all the allergies the person has (that they were
+tested for).
+
+The list of items (and their value) that were tested are:
+
+* eggs (1)
+* peanuts (2)
+* shellfish (4)
+* strawberries (8)
+* tomatoes (16)
+* chocolate (32)
+* pollen (64)
+* cats (128)
+
+So if Tom is allergic to peanuts and chocolate, he gets a score of 34.
+
+Now, given just that score of 34, your program should be able to say:
+
+- Whether Tom is allergic to any one of those allergens listed above.
+- All the allergens Tom is allergic to.
+
+Note: a given score may include allergens **not** listed above (i.e.
+allergens that score 256, 512, 1024, etc.).  Your program should
+ignore those components of the score.  For example, if the allergy
+score is 257, your program should only report the eggs (1) allergy.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby allergies_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride allergies_test.rb
+
+
+## Source
+
+Jumpstart Lab Warm-up [http://jumpstartlab.com](http://jumpstartlab.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/allergies/allergies_test.rb
+++ b/exercises/allergies/allergies_test.rb
@@ -1,0 +1,103 @@
+require 'minitest/autorun'
+require_relative 'allergies'
+
+# Common test data version: 1.0.0 879bc89
+class AllergiesTest < Minitest::Test
+  def test_no_allergies_means_not_allergic
+    # skip
+    allergies = Allergies.new(0)
+    refute allergies.allergic_to?('peanuts')
+    refute allergies.allergic_to?('cats')
+    refute allergies.allergic_to?('strawberries')
+  end
+
+  def test_is_allergic_to_eggs
+    skip
+    allergies = Allergies.new(1)
+    assert allergies.allergic_to?('eggs')
+  end
+
+  def test_allergic_to_eggs_in_addition_to_other_stuff
+    skip
+    allergies = Allergies.new(5)
+    assert allergies.allergic_to?('eggs')
+    assert allergies.allergic_to?('shellfish')
+    refute allergies.allergic_to?('strawberries')
+  end
+
+  def test_no_allergies_at_all
+    skip
+    allergies = Allergies.new(0)
+    assert_equal %w(), allergies.list
+  end
+
+  def test_allergic_to_just_eggs
+    skip
+    allergies = Allergies.new(1)
+    assert_equal %w(eggs), allergies.list
+  end
+
+  def test_allergic_to_just_peanuts
+    skip
+    allergies = Allergies.new(2)
+    assert_equal %w(peanuts), allergies.list
+  end
+
+  def test_allergic_to_just_strawberries
+    skip
+    allergies = Allergies.new(8)
+    assert_equal %w(strawberries), allergies.list
+  end
+
+  def test_allergic_to_eggs_and_peanuts
+    skip
+    allergies = Allergies.new(3)
+    assert_equal %w(eggs peanuts), allergies.list
+  end
+
+  def test_allergic_to_more_than_eggs_but_not_peanuts
+    skip
+    allergies = Allergies.new(5)
+    assert_equal %w(eggs shellfish), allergies.list
+  end
+
+  def test_allergic_to_lots_of_stuff
+    skip
+    allergies = Allergies.new(248)
+    assert_equal %w(strawberries tomatoes chocolate pollen cats), allergies.list
+  end
+
+  def test_allergic_to_everything
+    skip
+    allergies = Allergies.new(255)
+    assert_equal %w(eggs peanuts shellfish strawberries tomatoes chocolate pollen cats), allergies.list
+  end
+
+  def test_ignore_non_allergen_score_parts
+    skip
+    allergies = Allergies.new(509)
+    assert_equal %w(eggs shellfish strawberries tomatoes chocolate pollen cats), allergies.list
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/alphametics/README.md
+++ b/exercises/alphametics/README.md
@@ -1,0 +1,58 @@
+# Alphametics
+
+Write a function to solve alphametics puzzles.
+
+[Alphametics](https://en.wikipedia.org/wiki/Alphametics) is a puzzle where
+letters in words are replaced with numbers.
+
+For example `SEND + MORE = MONEY`:
+
+```text
+  S E N D
+  M O R E +
+-----------
+M O N E Y
+```
+
+Replacing these with valid numbers gives:
+
+```text
+  9 5 6 7
+  1 0 8 5 +
+-----------
+1 0 6 5 2
+```
+
+This is correct because every letter is replaced by a different number and the
+words, translated into numbers, then make a valid sum.
+
+Each letter must represent a different digit, and the leading digit of
+a multi-digit number must not be zero.
+
+Write a function to solve alphametics puzzles.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby alphametics_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride alphametics_test.rb
+
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/alphametics/alphametics_test.rb
+++ b/exercises/alphametics/alphametics_test.rb
@@ -1,0 +1,95 @@
+require 'minitest/autorun'
+require_relative 'alphametics'
+
+# Common test data version: 1.0.0 b9bada8
+class AlphameticsTest < Minitest::Test
+
+  def test_puzzle_with_three_letters
+    # skip
+    input = 'I + BB == ILL'
+    expected = { 'B' => 9, 'I' => 1, 'L' => 0 }
+    assert_equal expected, Alphametics.solve(input)
+  end
+
+  def test_solution_must_have_unique_value_for_each_letter
+    skip
+    input = 'A == B'
+    expected = {}
+    assert_equal expected, Alphametics.solve(input)
+  end
+
+  def test_leading_zero_solution_is_invalid
+    skip
+    input = 'ACA + DD == BD'
+    expected = {}
+    assert_equal expected, Alphametics.solve(input)
+  end
+
+  def test_puzzle_with_four_letters
+    skip
+    input = 'AS + A == MOM'
+    expected = { 'A' => 9, 'M' => 1, 'O' => 0, 'S' => 2 }
+    assert_equal expected, Alphametics.solve(input)
+  end
+
+  def test_puzzle_with_six_letters
+    skip
+    input = 'NO + NO + TOO == LATE'
+    expected = { 'A' => 0, 'E' => 2, 'L' => 1, 'N' => 7,
+                 'O' => 4, 'T' => 9 }
+    assert_equal expected, Alphametics.solve(input)
+  end
+
+  def test_puzzle_with_seven_letters
+    skip
+    input = 'HE + SEES + THE == LIGHT'
+    expected = { 'E' => 4, 'G' => 2, 'H' => 5, 'I' => 0,
+                 'L' => 1, 'S' => 9, 'T' => 7 }
+    assert_equal expected, Alphametics.solve(input)
+  end
+
+  # The obvious algorithm can take a long time to solve this puzzle,
+  # but an optimised solution can solve it fairly quickly.
+  # (It's OK to submit your solution without getting this test to pass.)
+  def test_puzzle_with_eight_letters
+    skip
+    input = 'SEND + MORE == MONEY'
+    expected = { 'D' => 7, 'E' => 5, 'M' => 1, 'N' => 6,
+                 'O' => 0, 'R' => 8, 'S' => 9, 'Y' => 2 }
+    assert_equal expected, Alphametics.solve(input)
+  end
+
+  # The obvious algorithm can take a long time to solve this puzzle,
+  # but an optimised solution can solve it fairly quickly.
+  # (It's OK to submit your solution without getting this test to pass.)
+  def test_puzzle_with_ten_letters
+    skip
+    input = 'AND + A + STRONG + OFFENSE + AS + A + GOOD == DEFENSE'
+    expected = { 'A' => 5, 'D' => 3, 'E' => 4, 'F' => 7,
+                 'G' => 8, 'N' => 0, 'O' => 2, 'R' => 1,
+                 'S' => 6, 'T' => 9 }
+    assert_equal expected, Alphametics.solve(input)
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 4, BookKeeping::VERSION
+  end
+end

--- a/exercises/alphanumeric-pattern-generator/README.md
+++ b/exercises/alphanumeric-pattern-generator/README.md
@@ -1,0 +1,33 @@
+# Alphanumeric Pattern Generator
+
+Create a program that can generate and manage [alphanumeric](https://en.wikipedia.org/wiki/Alphanumeric) strings based off a given pattern.
+
+An alphanumeric pattern is a string that contains alphabetic and numeric characters. In our example, `.` represents alphabetic characters (a-z) and `#` represents numeric characters (0-9), so the pattern `.#` could produce anything from `A0` to `Z9`.
+
+An alphanumeric patterns can also have constant values. For example, the pattern `#.JH1.` could generate any pattern including the values `JH1` as index 2 ,3 and 4 respectively such as `9FJH1P`.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby alphanumeric_pattern_generator_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride alphanumeric_pattern_generator_test.rb
+
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/alphanumeric-pattern-generator/alphanumeric_pattern_generator_test.rb
+++ b/exercises/alphanumeric-pattern-generator/alphanumeric_pattern_generator_test.rb
@@ -1,0 +1,156 @@
+require 'minitest/autorun'
+require_relative 'alphanumeric_pattern_generator'
+
+class PatternGeneratorTest < Minitest::Test
+  def test_it_can_verify_a_single_alphabetic_character
+    pattern = '.'
+    pg = PatternGenerator.new(pattern)
+
+    assert_equal true, pg.verify('F')
+    assert_equal false, pg.verify('0')
+  end
+
+  def test_it_verifies_upper_and_lowercase_characters
+    pattern = '.'
+    pg = PatternGenerator.new(pattern)
+
+    assert_equal true, pg.verify('r')
+    assert_equal true, pg.verify('R')
+  end
+
+  def test_it_generates_a_single_character_pattern
+    pattern = '.'
+    pg = PatternGenerator.new(pattern)
+
+    assert /[A-Z]/.match(pg.generate)
+    refute /[0-9]/.match(pg.generate)
+  end
+
+  def test_it_can_verify_a_single_numeric_character
+    pattern = '#'
+    pg = PatternGenerator.new(pattern)
+
+    assert_equal true, pg.verify('3')
+    assert_equal false, pg.verify('W')
+  end
+
+  def test_it_generates_a_single_numeric_pattern
+    pattern = '#'
+    pg = PatternGenerator.new(pattern)
+
+    assert /[0-9]/.match(pg.generate)
+    refute /[A-Z]/.match(pg.generate)
+  end
+
+  def test_it_verifies_more_complex_patterns
+    pattern = '.#.'
+    pg = PatternGenerator.new(pattern)
+
+    assert_equal true, pg.verify('A3A')
+    assert_equal true, pg.verify('a2a')
+    assert_equal false, pg.verify('AAA')
+  end
+
+  def test_it_generates_more_complex_patterns
+    pattern = '.#.'
+    pg = PatternGenerator.new(pattern)
+
+    assert /[A-Z][0-9][A-Z]/.match(pg.generate)
+  end
+
+  def test_it_verifies_patterns_with_specific_elements
+    pattern = '.##ZA3.#'
+    pg = PatternGenerator.new(pattern)
+
+    assert_equal true, pg.verify('a23za3h1')
+    assert_equal true, pg.verify('a23ZA3h1')
+    assert_equal false, pg.verify('a23az3h1')
+  end
+
+  def test_it_verifies_patterns_with_specific_elements_in_different_spots
+    pattern = 'A#23.9.F'
+    pg = PatternGenerator.new(pattern)
+
+    assert_equal true, pg.verify('A523B9CF')
+    assert_equal false, pg.verify('a123a8hf')
+  end
+
+  def test_it_generates_patterns_with_constants
+    pattern = 'A#23..#'
+    pg = PatternGenerator.new(pattern)
+
+    assert /A[0-9]23[A-Z][A-Z][0-9]/.match(pg.generate)
+  end
+
+  def test_it_generates_nth_value_of_patterns
+    pattern = '.#.'
+    pg = PatternGenerator.new(pattern)
+
+    assert_equal 'A0A', pg.generate(0)
+    assert_equal 'A1B', pg.generate(27)
+    assert_equal 'Z9Z', pg.generate(6759)
+    assert_equal 'Z9Y', pg.generate(6758)
+  end
+
+  def test_it_raises_exception_if_invalid_valure_is_passed_to_generate
+    pattern = '.#.'
+    pg = PatternGenerator.new(pattern)
+
+    assert_raises(ArgumentError) { pg.generate(10000) }
+    assert_raises(ArgumentError) { pg.generate(-25) }
+  end
+
+  def test_it_generates_nth_value_of_patterns
+    pattern = '.#.'
+    pg = PatternGenerator.new(pattern)
+
+    assert_equal 'A0A', pg.generate(0)
+    assert_equal 'A1B', pg.generate(27)
+    assert_equal 'Z9Z', pg.generate(6759)
+    assert_equal 'Z9Y', pg.generate(6758)
+  end
+
+  def test_it_generates_nth_value_of_patterns_with_constants
+    pattern = 'R#..W'
+    pg = PatternGenerator.new(pattern)
+
+    assert_equal 'R0AAW', pg.generate(0)
+    assert_equal 'R0BAW', pg.generate(26)
+    assert_equal 'R9ZYW', pg.generate(6758)
+  end
+
+  def test_it_generates_the_total_available_patterns
+    pattern = '.#.'
+    pg = PatternGenerator.new(pattern)
+
+    assert_equal 6760, pg.total_available
+  end
+
+  def test_it_generates_the_total_available_patterns_with_constants
+    pattern = '.1.'
+    pg = PatternGenerator.new(pattern)
+
+    assert_equal 676, pg.total_available
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -1,0 +1,37 @@
+# Anagram
+
+Given a word and a list of possible anagrams, select the correct sublist.
+
+Given `"listen"` and a list of candidates like `"enlists" "google"
+"inlets" "banana"` the program should return a list containing
+`"inlets"`.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby anagram_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride anagram_test.rb
+
+
+## Source
+
+Inspired by the Extreme Startup game [https://github.com/rchatley/extreme_startup](https://github.com/rchatley/extreme_startup)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/anagram/anagram_test.rb
+++ b/exercises/anagram/anagram_test.rb
@@ -1,0 +1,155 @@
+require 'minitest/autorun'
+require_relative 'anagram'
+
+# Common test data version: 1.0.1 196fc1a
+class AnagramTest < Minitest::Test
+  def test_no_matches
+    # skip
+    detector = Anagram.new('diaper')
+    anagrams = detector.match(["hello", "world", "zombies", "pants"])
+    expected = []
+    assert_equal expected, anagrams
+  end
+
+  def test_detects_simple_anagram
+    skip
+    detector = Anagram.new('ant')
+    anagrams = detector.match(["tan", "stand", "at"])
+    expected = ["tan"]
+    assert_equal expected, anagrams
+  end
+
+  def test_does_not_detect_false_positives
+    skip
+    detector = Anagram.new('galea')
+    anagrams = detector.match(["eagle"])
+    expected = []
+    assert_equal expected, anagrams
+  end
+
+  def test_detects_two_anagrams
+    skip
+    detector = Anagram.new('master')
+    anagrams = detector.match(["stream", "pigeon", "maters"])
+    expected = ["maters", "stream"]
+    assert_equal expected, anagrams.sort
+  end
+
+  def test_does_not_detect_anagram_subsets
+    skip
+    detector = Anagram.new('good')
+    anagrams = detector.match(["dog", "goody"])
+    expected = []
+    assert_equal expected, anagrams
+  end
+
+  def test_detects_anagram
+    skip
+    detector = Anagram.new('listen')
+    anagrams = detector.match(["enlists", "google", "inlets", "banana"])
+    expected = ["inlets"]
+    assert_equal expected, anagrams
+  end
+
+  def test_detects_three_anagrams
+    skip
+    detector = Anagram.new('allergy')
+    anagrams = detector.match(["gallery", "ballerina", "regally", "clergy", "largely", "leading"])
+    expected = ["gallery", "largely", "regally"]
+    assert_equal expected, anagrams.sort
+  end
+
+  def test_does_not_detect_identical_words
+    skip
+    detector = Anagram.new('corn')
+    anagrams = detector.match(["corn", "dark", "Corn", "rank", "CORN", "cron", "park"])
+    expected = ["cron"]
+    assert_equal expected, anagrams
+  end
+
+  def test_does_not_detect_non_anagrams_with_identical_checksum
+    skip
+    detector = Anagram.new('mass')
+    anagrams = detector.match(["last"])
+    expected = []
+    assert_equal expected, anagrams
+  end
+
+  def test_detects_anagrams_case_insensitively
+    skip
+    detector = Anagram.new('Orchestra')
+    anagrams = detector.match(["cashregister", "Carthorse", "radishes"])
+    expected = ["Carthorse"]
+    assert_equal expected, anagrams
+  end
+
+  def test_detects_anagrams_using_case_insensitive_subject
+    skip
+    detector = Anagram.new('Orchestra')
+    anagrams = detector.match(["cashregister", "carthorse", "radishes"])
+    expected = ["carthorse"]
+    assert_equal expected, anagrams
+  end
+
+  def test_detects_anagrams_using_case_insensitive_possible_matches
+    skip
+    detector = Anagram.new('orchestra')
+    anagrams = detector.match(["cashregister", "Carthorse", "radishes"])
+    expected = ["Carthorse"]
+    assert_equal expected, anagrams
+  end
+
+  def test_does_not_detect_a_word_as_its_own_anagram
+    skip
+    detector = Anagram.new('banana')
+    anagrams = detector.match(["Banana"])
+    expected = []
+    assert_equal expected, anagrams
+  end
+
+  def test_does_not_detect_a_anagram_if_the_original_word_is_repeated
+    skip
+    detector = Anagram.new('go')
+    anagrams = detector.match(["go Go GO"])
+    expected = []
+    assert_equal expected, anagrams
+  end
+
+  def test_anagrams_must_use_all_letters_exactly_once
+    skip
+    detector = Anagram.new('tapper')
+    anagrams = detector.match(["patter"])
+    expected = []
+    assert_equal expected, anagrams
+  end
+
+  def test_capital_word_is_not_own_anagram
+    skip
+    detector = Anagram.new('BANANA')
+    anagrams = detector.match(["Banana"])
+    expected = []
+    assert_equal expected, anagrams
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 2, BookKeeping::VERSION
+  end
+end

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -1,0 +1,59 @@
+# Atbash Cipher
+
+Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.
+
+The Atbash cipher is a simple substitution cipher that relies on
+transposing all the letters in the alphabet such that the resulting
+alphabet is backwards. The first letter is replaced with the last
+letter, the second with the second-last, and so on.
+
+An Atbash cipher for the Latin alphabet would be as follows:
+
+```text
+Plain:  abcdefghijklmnopqrstuvwxyz
+Cipher: zyxwvutsrqponmlkjihgfedcba
+```
+
+It is a very weak cipher because it only has one possible key, and it is
+a simple monoalphabetic substitution cipher. However, this may not have
+been an issue in the cipher's time.
+
+Ciphertext is written out in groups of fixed length, the traditional group size
+being 5 letters, and punctuation is excluded. This is to make it harder to guess
+things based on word boundaries.
+
+## Examples
+
+- Encoding `test` gives `gvhg`
+- Decoding `gvhg` gives `test`
+- Decoding `gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt` gives `thequickbrownfoxjumpsoverthelazydog`
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby atbash_cipher_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride atbash_cipher_test.rb
+
+
+## Source
+
+Wikipedia [http://en.wikipedia.org/wiki/Atbash](http://en.wikipedia.org/wiki/Atbash)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/atbash-cipher/atbash_cipher_test.rb
+++ b/exercises/atbash-cipher/atbash_cipher_test.rb
@@ -1,0 +1,46 @@
+require 'minitest/autorun'
+require_relative 'atbash_cipher'
+
+class AtbashTest < Minitest::Test
+  def test_encode_no
+    assert_equal 'ml', Atbash.encode('no')
+  end
+
+  def test_encode_yes
+    skip
+    assert_equal 'bvh', Atbash.encode('yes')
+  end
+
+  def test_encode_OMG
+    skip
+    assert_equal 'lnt', Atbash.encode('OMG')
+  end
+
+  def test_encode_O_M_G
+    skip
+    assert_equal 'lnt', Atbash.encode('O M G')
+  end
+
+  def test_encode_long_word
+    skip
+    assert_equal 'nrmwy oldrm tob', Atbash.encode('mindblowingly')
+  end
+
+  def test_encode_numbers
+    skip
+    assert_equal('gvhgr mt123 gvhgr mt',
+                 Atbash.encode('Testing, 1 2 3, testing.'))
+  end
+
+  def test_encode_sentence
+    skip
+    assert_equal 'gifgs rhurx grlm', Atbash.encode('Truth is fiction.')
+  end
+
+  def test_encode_all_the_things
+    skip
+    plaintext = 'The quick brown fox jumps over the lazy dog.'
+    cipher = 'gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt'
+    assert_equal cipher, Atbash.encode(plaintext)
+  end
+end

--- a/exercises/beer-song/README.md
+++ b/exercises/beer-song/README.md
@@ -1,0 +1,351 @@
+# Beer Song
+
+Recite the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.
+
+Note that not all verses are identical.
+
+```text
+99 bottles of beer on the wall, 99 bottles of beer.
+Take one down and pass it around, 98 bottles of beer on the wall.
+
+98 bottles of beer on the wall, 98 bottles of beer.
+Take one down and pass it around, 97 bottles of beer on the wall.
+
+97 bottles of beer on the wall, 97 bottles of beer.
+Take one down and pass it around, 96 bottles of beer on the wall.
+
+96 bottles of beer on the wall, 96 bottles of beer.
+Take one down and pass it around, 95 bottles of beer on the wall.
+
+95 bottles of beer on the wall, 95 bottles of beer.
+Take one down and pass it around, 94 bottles of beer on the wall.
+
+94 bottles of beer on the wall, 94 bottles of beer.
+Take one down and pass it around, 93 bottles of beer on the wall.
+
+93 bottles of beer on the wall, 93 bottles of beer.
+Take one down and pass it around, 92 bottles of beer on the wall.
+
+92 bottles of beer on the wall, 92 bottles of beer.
+Take one down and pass it around, 91 bottles of beer on the wall.
+
+91 bottles of beer on the wall, 91 bottles of beer.
+Take one down and pass it around, 90 bottles of beer on the wall.
+
+90 bottles of beer on the wall, 90 bottles of beer.
+Take one down and pass it around, 89 bottles of beer on the wall.
+
+89 bottles of beer on the wall, 89 bottles of beer.
+Take one down and pass it around, 88 bottles of beer on the wall.
+
+88 bottles of beer on the wall, 88 bottles of beer.
+Take one down and pass it around, 87 bottles of beer on the wall.
+
+87 bottles of beer on the wall, 87 bottles of beer.
+Take one down and pass it around, 86 bottles of beer on the wall.
+
+86 bottles of beer on the wall, 86 bottles of beer.
+Take one down and pass it around, 85 bottles of beer on the wall.
+
+85 bottles of beer on the wall, 85 bottles of beer.
+Take one down and pass it around, 84 bottles of beer on the wall.
+
+84 bottles of beer on the wall, 84 bottles of beer.
+Take one down and pass it around, 83 bottles of beer on the wall.
+
+83 bottles of beer on the wall, 83 bottles of beer.
+Take one down and pass it around, 82 bottles of beer on the wall.
+
+82 bottles of beer on the wall, 82 bottles of beer.
+Take one down and pass it around, 81 bottles of beer on the wall.
+
+81 bottles of beer on the wall, 81 bottles of beer.
+Take one down and pass it around, 80 bottles of beer on the wall.
+
+80 bottles of beer on the wall, 80 bottles of beer.
+Take one down and pass it around, 79 bottles of beer on the wall.
+
+79 bottles of beer on the wall, 79 bottles of beer.
+Take one down and pass it around, 78 bottles of beer on the wall.
+
+78 bottles of beer on the wall, 78 bottles of beer.
+Take one down and pass it around, 77 bottles of beer on the wall.
+
+77 bottles of beer on the wall, 77 bottles of beer.
+Take one down and pass it around, 76 bottles of beer on the wall.
+
+76 bottles of beer on the wall, 76 bottles of beer.
+Take one down and pass it around, 75 bottles of beer on the wall.
+
+75 bottles of beer on the wall, 75 bottles of beer.
+Take one down and pass it around, 74 bottles of beer on the wall.
+
+74 bottles of beer on the wall, 74 bottles of beer.
+Take one down and pass it around, 73 bottles of beer on the wall.
+
+73 bottles of beer on the wall, 73 bottles of beer.
+Take one down and pass it around, 72 bottles of beer on the wall.
+
+72 bottles of beer on the wall, 72 bottles of beer.
+Take one down and pass it around, 71 bottles of beer on the wall.
+
+71 bottles of beer on the wall, 71 bottles of beer.
+Take one down and pass it around, 70 bottles of beer on the wall.
+
+70 bottles of beer on the wall, 70 bottles of beer.
+Take one down and pass it around, 69 bottles of beer on the wall.
+
+69 bottles of beer on the wall, 69 bottles of beer.
+Take one down and pass it around, 68 bottles of beer on the wall.
+
+68 bottles of beer on the wall, 68 bottles of beer.
+Take one down and pass it around, 67 bottles of beer on the wall.
+
+67 bottles of beer on the wall, 67 bottles of beer.
+Take one down and pass it around, 66 bottles of beer on the wall.
+
+66 bottles of beer on the wall, 66 bottles of beer.
+Take one down and pass it around, 65 bottles of beer on the wall.
+
+65 bottles of beer on the wall, 65 bottles of beer.
+Take one down and pass it around, 64 bottles of beer on the wall.
+
+64 bottles of beer on the wall, 64 bottles of beer.
+Take one down and pass it around, 63 bottles of beer on the wall.
+
+63 bottles of beer on the wall, 63 bottles of beer.
+Take one down and pass it around, 62 bottles of beer on the wall.
+
+62 bottles of beer on the wall, 62 bottles of beer.
+Take one down and pass it around, 61 bottles of beer on the wall.
+
+61 bottles of beer on the wall, 61 bottles of beer.
+Take one down and pass it around, 60 bottles of beer on the wall.
+
+60 bottles of beer on the wall, 60 bottles of beer.
+Take one down and pass it around, 59 bottles of beer on the wall.
+
+59 bottles of beer on the wall, 59 bottles of beer.
+Take one down and pass it around, 58 bottles of beer on the wall.
+
+58 bottles of beer on the wall, 58 bottles of beer.
+Take one down and pass it around, 57 bottles of beer on the wall.
+
+57 bottles of beer on the wall, 57 bottles of beer.
+Take one down and pass it around, 56 bottles of beer on the wall.
+
+56 bottles of beer on the wall, 56 bottles of beer.
+Take one down and pass it around, 55 bottles of beer on the wall.
+
+55 bottles of beer on the wall, 55 bottles of beer.
+Take one down and pass it around, 54 bottles of beer on the wall.
+
+54 bottles of beer on the wall, 54 bottles of beer.
+Take one down and pass it around, 53 bottles of beer on the wall.
+
+53 bottles of beer on the wall, 53 bottles of beer.
+Take one down and pass it around, 52 bottles of beer on the wall.
+
+52 bottles of beer on the wall, 52 bottles of beer.
+Take one down and pass it around, 51 bottles of beer on the wall.
+
+51 bottles of beer on the wall, 51 bottles of beer.
+Take one down and pass it around, 50 bottles of beer on the wall.
+
+50 bottles of beer on the wall, 50 bottles of beer.
+Take one down and pass it around, 49 bottles of beer on the wall.
+
+49 bottles of beer on the wall, 49 bottles of beer.
+Take one down and pass it around, 48 bottles of beer on the wall.
+
+48 bottles of beer on the wall, 48 bottles of beer.
+Take one down and pass it around, 47 bottles of beer on the wall.
+
+47 bottles of beer on the wall, 47 bottles of beer.
+Take one down and pass it around, 46 bottles of beer on the wall.
+
+46 bottles of beer on the wall, 46 bottles of beer.
+Take one down and pass it around, 45 bottles of beer on the wall.
+
+45 bottles of beer on the wall, 45 bottles of beer.
+Take one down and pass it around, 44 bottles of beer on the wall.
+
+44 bottles of beer on the wall, 44 bottles of beer.
+Take one down and pass it around, 43 bottles of beer on the wall.
+
+43 bottles of beer on the wall, 43 bottles of beer.
+Take one down and pass it around, 42 bottles of beer on the wall.
+
+42 bottles of beer on the wall, 42 bottles of beer.
+Take one down and pass it around, 41 bottles of beer on the wall.
+
+41 bottles of beer on the wall, 41 bottles of beer.
+Take one down and pass it around, 40 bottles of beer on the wall.
+
+40 bottles of beer on the wall, 40 bottles of beer.
+Take one down and pass it around, 39 bottles of beer on the wall.
+
+39 bottles of beer on the wall, 39 bottles of beer.
+Take one down and pass it around, 38 bottles of beer on the wall.
+
+38 bottles of beer on the wall, 38 bottles of beer.
+Take one down and pass it around, 37 bottles of beer on the wall.
+
+37 bottles of beer on the wall, 37 bottles of beer.
+Take one down and pass it around, 36 bottles of beer on the wall.
+
+36 bottles of beer on the wall, 36 bottles of beer.
+Take one down and pass it around, 35 bottles of beer on the wall.
+
+35 bottles of beer on the wall, 35 bottles of beer.
+Take one down and pass it around, 34 bottles of beer on the wall.
+
+34 bottles of beer on the wall, 34 bottles of beer.
+Take one down and pass it around, 33 bottles of beer on the wall.
+
+33 bottles of beer on the wall, 33 bottles of beer.
+Take one down and pass it around, 32 bottles of beer on the wall.
+
+32 bottles of beer on the wall, 32 bottles of beer.
+Take one down and pass it around, 31 bottles of beer on the wall.
+
+31 bottles of beer on the wall, 31 bottles of beer.
+Take one down and pass it around, 30 bottles of beer on the wall.
+
+30 bottles of beer on the wall, 30 bottles of beer.
+Take one down and pass it around, 29 bottles of beer on the wall.
+
+29 bottles of beer on the wall, 29 bottles of beer.
+Take one down and pass it around, 28 bottles of beer on the wall.
+
+28 bottles of beer on the wall, 28 bottles of beer.
+Take one down and pass it around, 27 bottles of beer on the wall.
+
+27 bottles of beer on the wall, 27 bottles of beer.
+Take one down and pass it around, 26 bottles of beer on the wall.
+
+26 bottles of beer on the wall, 26 bottles of beer.
+Take one down and pass it around, 25 bottles of beer on the wall.
+
+25 bottles of beer on the wall, 25 bottles of beer.
+Take one down and pass it around, 24 bottles of beer on the wall.
+
+24 bottles of beer on the wall, 24 bottles of beer.
+Take one down and pass it around, 23 bottles of beer on the wall.
+
+23 bottles of beer on the wall, 23 bottles of beer.
+Take one down and pass it around, 22 bottles of beer on the wall.
+
+22 bottles of beer on the wall, 22 bottles of beer.
+Take one down and pass it around, 21 bottles of beer on the wall.
+
+21 bottles of beer on the wall, 21 bottles of beer.
+Take one down and pass it around, 20 bottles of beer on the wall.
+
+20 bottles of beer on the wall, 20 bottles of beer.
+Take one down and pass it around, 19 bottles of beer on the wall.
+
+19 bottles of beer on the wall, 19 bottles of beer.
+Take one down and pass it around, 18 bottles of beer on the wall.
+
+18 bottles of beer on the wall, 18 bottles of beer.
+Take one down and pass it around, 17 bottles of beer on the wall.
+
+17 bottles of beer on the wall, 17 bottles of beer.
+Take one down and pass it around, 16 bottles of beer on the wall.
+
+16 bottles of beer on the wall, 16 bottles of beer.
+Take one down and pass it around, 15 bottles of beer on the wall.
+
+15 bottles of beer on the wall, 15 bottles of beer.
+Take one down and pass it around, 14 bottles of beer on the wall.
+
+14 bottles of beer on the wall, 14 bottles of beer.
+Take one down and pass it around, 13 bottles of beer on the wall.
+
+13 bottles of beer on the wall, 13 bottles of beer.
+Take one down and pass it around, 12 bottles of beer on the wall.
+
+12 bottles of beer on the wall, 12 bottles of beer.
+Take one down and pass it around, 11 bottles of beer on the wall.
+
+11 bottles of beer on the wall, 11 bottles of beer.
+Take one down and pass it around, 10 bottles of beer on the wall.
+
+10 bottles of beer on the wall, 10 bottles of beer.
+Take one down and pass it around, 9 bottles of beer on the wall.
+
+9 bottles of beer on the wall, 9 bottles of beer.
+Take one down and pass it around, 8 bottles of beer on the wall.
+
+8 bottles of beer on the wall, 8 bottles of beer.
+Take one down and pass it around, 7 bottles of beer on the wall.
+
+7 bottles of beer on the wall, 7 bottles of beer.
+Take one down and pass it around, 6 bottles of beer on the wall.
+
+6 bottles of beer on the wall, 6 bottles of beer.
+Take one down and pass it around, 5 bottles of beer on the wall.
+
+5 bottles of beer on the wall, 5 bottles of beer.
+Take one down and pass it around, 4 bottles of beer on the wall.
+
+4 bottles of beer on the wall, 4 bottles of beer.
+Take one down and pass it around, 3 bottles of beer on the wall.
+
+3 bottles of beer on the wall, 3 bottles of beer.
+Take one down and pass it around, 2 bottles of beer on the wall.
+
+2 bottles of beer on the wall, 2 bottles of beer.
+Take one down and pass it around, 1 bottle of beer on the wall.
+
+1 bottle of beer on the wall, 1 bottle of beer.
+Take it down and pass it around, no more bottles of beer on the wall.
+
+No more bottles of beer on the wall, no more bottles of beer.
+Go to the store and buy some more, 99 bottles of beer on the wall.
+```
+
+## For bonus points
+
+Did you get the tests passing and the code clean? If you want to, these
+are some additional things you could try:
+
+* Remove as much duplication as you possibly can.
+* Optimize for readability, even if it means introducing duplication.
+* If you've removed all the duplication, do you have a lot of
+  conditionals? Try replacing the conditionals with polymorphism, if it
+  applies in this language. How readable is it?
+
+Then please share your thoughts in a comment on the submission. Did this
+experiment make the code better? Worse? Did you learn anything from it?
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby beer_song_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride beer_song_test.rb
+
+
+## Source
+
+Learn to Program by Chris Pine [http://pine.fm/LearnToProgram/?Chapter=06](http://pine.fm/LearnToProgram/?Chapter=06)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/beer-song/beer_song_test.rb
+++ b/exercises/beer-song/beer_song_test.rb
@@ -1,0 +1,405 @@
+require 'minitest/autorun'
+require_relative 'beer_song'
+
+# Common test data version: 1.0.0 9f3d48a
+class BeerSongTest < Minitest::Test
+  def test_first_generic_verse
+    # skip
+    expected = <<-TEXT
+99 bottles of beer on the wall, 99 bottles of beer.
+Take one down and pass it around, 98 bottles of beer on the wall.
+TEXT
+    assert_equal expected, BeerSong.new.verse(99)
+  end
+
+  def test_last_generic_verse
+    skip
+    expected = <<-TEXT
+3 bottles of beer on the wall, 3 bottles of beer.
+Take one down and pass it around, 2 bottles of beer on the wall.
+TEXT
+    assert_equal expected, BeerSong.new.verse(3)
+  end
+
+  def test_verse_2
+    skip
+    expected = <<-TEXT
+2 bottles of beer on the wall, 2 bottles of beer.
+Take one down and pass it around, 1 bottle of beer on the wall.
+TEXT
+    assert_equal expected, BeerSong.new.verse(2)
+  end
+
+  def test_verse_1
+    skip
+    expected = <<-TEXT
+1 bottle of beer on the wall, 1 bottle of beer.
+Take it down and pass it around, no more bottles of beer on the wall.
+TEXT
+    assert_equal expected, BeerSong.new.verse(1)
+  end
+
+  def test_verse_0
+    skip
+    expected = <<-TEXT
+No more bottles of beer on the wall, no more bottles of beer.
+Go to the store and buy some more, 99 bottles of beer on the wall.
+TEXT
+    assert_equal expected, BeerSong.new.verse(0)
+  end
+
+  def test_first_two_verses
+    skip
+    expected = <<-TEXT
+99 bottles of beer on the wall, 99 bottles of beer.
+Take one down and pass it around, 98 bottles of beer on the wall.
+
+98 bottles of beer on the wall, 98 bottles of beer.
+Take one down and pass it around, 97 bottles of beer on the wall.
+TEXT
+    assert_equal expected, BeerSong.new.verses(99, 98)
+  end
+
+  def test_last_three_verses
+    skip
+    expected = <<-TEXT
+2 bottles of beer on the wall, 2 bottles of beer.
+Take one down and pass it around, 1 bottle of beer on the wall.
+
+1 bottle of beer on the wall, 1 bottle of beer.
+Take it down and pass it around, no more bottles of beer on the wall.
+
+No more bottles of beer on the wall, no more bottles of beer.
+Go to the store and buy some more, 99 bottles of beer on the wall.
+TEXT
+    assert_equal expected, BeerSong.new.verses(2, 0)
+  end
+
+  def test_all_verses
+    skip
+    expected = <<-TEXT
+99 bottles of beer on the wall, 99 bottles of beer.
+Take one down and pass it around, 98 bottles of beer on the wall.
+
+98 bottles of beer on the wall, 98 bottles of beer.
+Take one down and pass it around, 97 bottles of beer on the wall.
+
+97 bottles of beer on the wall, 97 bottles of beer.
+Take one down and pass it around, 96 bottles of beer on the wall.
+
+96 bottles of beer on the wall, 96 bottles of beer.
+Take one down and pass it around, 95 bottles of beer on the wall.
+
+95 bottles of beer on the wall, 95 bottles of beer.
+Take one down and pass it around, 94 bottles of beer on the wall.
+
+94 bottles of beer on the wall, 94 bottles of beer.
+Take one down and pass it around, 93 bottles of beer on the wall.
+
+93 bottles of beer on the wall, 93 bottles of beer.
+Take one down and pass it around, 92 bottles of beer on the wall.
+
+92 bottles of beer on the wall, 92 bottles of beer.
+Take one down and pass it around, 91 bottles of beer on the wall.
+
+91 bottles of beer on the wall, 91 bottles of beer.
+Take one down and pass it around, 90 bottles of beer on the wall.
+
+90 bottles of beer on the wall, 90 bottles of beer.
+Take one down and pass it around, 89 bottles of beer on the wall.
+
+89 bottles of beer on the wall, 89 bottles of beer.
+Take one down and pass it around, 88 bottles of beer on the wall.
+
+88 bottles of beer on the wall, 88 bottles of beer.
+Take one down and pass it around, 87 bottles of beer on the wall.
+
+87 bottles of beer on the wall, 87 bottles of beer.
+Take one down and pass it around, 86 bottles of beer on the wall.
+
+86 bottles of beer on the wall, 86 bottles of beer.
+Take one down and pass it around, 85 bottles of beer on the wall.
+
+85 bottles of beer on the wall, 85 bottles of beer.
+Take one down and pass it around, 84 bottles of beer on the wall.
+
+84 bottles of beer on the wall, 84 bottles of beer.
+Take one down and pass it around, 83 bottles of beer on the wall.
+
+83 bottles of beer on the wall, 83 bottles of beer.
+Take one down and pass it around, 82 bottles of beer on the wall.
+
+82 bottles of beer on the wall, 82 bottles of beer.
+Take one down and pass it around, 81 bottles of beer on the wall.
+
+81 bottles of beer on the wall, 81 bottles of beer.
+Take one down and pass it around, 80 bottles of beer on the wall.
+
+80 bottles of beer on the wall, 80 bottles of beer.
+Take one down and pass it around, 79 bottles of beer on the wall.
+
+79 bottles of beer on the wall, 79 bottles of beer.
+Take one down and pass it around, 78 bottles of beer on the wall.
+
+78 bottles of beer on the wall, 78 bottles of beer.
+Take one down and pass it around, 77 bottles of beer on the wall.
+
+77 bottles of beer on the wall, 77 bottles of beer.
+Take one down and pass it around, 76 bottles of beer on the wall.
+
+76 bottles of beer on the wall, 76 bottles of beer.
+Take one down and pass it around, 75 bottles of beer on the wall.
+
+75 bottles of beer on the wall, 75 bottles of beer.
+Take one down and pass it around, 74 bottles of beer on the wall.
+
+74 bottles of beer on the wall, 74 bottles of beer.
+Take one down and pass it around, 73 bottles of beer on the wall.
+
+73 bottles of beer on the wall, 73 bottles of beer.
+Take one down and pass it around, 72 bottles of beer on the wall.
+
+72 bottles of beer on the wall, 72 bottles of beer.
+Take one down and pass it around, 71 bottles of beer on the wall.
+
+71 bottles of beer on the wall, 71 bottles of beer.
+Take one down and pass it around, 70 bottles of beer on the wall.
+
+70 bottles of beer on the wall, 70 bottles of beer.
+Take one down and pass it around, 69 bottles of beer on the wall.
+
+69 bottles of beer on the wall, 69 bottles of beer.
+Take one down and pass it around, 68 bottles of beer on the wall.
+
+68 bottles of beer on the wall, 68 bottles of beer.
+Take one down and pass it around, 67 bottles of beer on the wall.
+
+67 bottles of beer on the wall, 67 bottles of beer.
+Take one down and pass it around, 66 bottles of beer on the wall.
+
+66 bottles of beer on the wall, 66 bottles of beer.
+Take one down and pass it around, 65 bottles of beer on the wall.
+
+65 bottles of beer on the wall, 65 bottles of beer.
+Take one down and pass it around, 64 bottles of beer on the wall.
+
+64 bottles of beer on the wall, 64 bottles of beer.
+Take one down and pass it around, 63 bottles of beer on the wall.
+
+63 bottles of beer on the wall, 63 bottles of beer.
+Take one down and pass it around, 62 bottles of beer on the wall.
+
+62 bottles of beer on the wall, 62 bottles of beer.
+Take one down and pass it around, 61 bottles of beer on the wall.
+
+61 bottles of beer on the wall, 61 bottles of beer.
+Take one down and pass it around, 60 bottles of beer on the wall.
+
+60 bottles of beer on the wall, 60 bottles of beer.
+Take one down and pass it around, 59 bottles of beer on the wall.
+
+59 bottles of beer on the wall, 59 bottles of beer.
+Take one down and pass it around, 58 bottles of beer on the wall.
+
+58 bottles of beer on the wall, 58 bottles of beer.
+Take one down and pass it around, 57 bottles of beer on the wall.
+
+57 bottles of beer on the wall, 57 bottles of beer.
+Take one down and pass it around, 56 bottles of beer on the wall.
+
+56 bottles of beer on the wall, 56 bottles of beer.
+Take one down and pass it around, 55 bottles of beer on the wall.
+
+55 bottles of beer on the wall, 55 bottles of beer.
+Take one down and pass it around, 54 bottles of beer on the wall.
+
+54 bottles of beer on the wall, 54 bottles of beer.
+Take one down and pass it around, 53 bottles of beer on the wall.
+
+53 bottles of beer on the wall, 53 bottles of beer.
+Take one down and pass it around, 52 bottles of beer on the wall.
+
+52 bottles of beer on the wall, 52 bottles of beer.
+Take one down and pass it around, 51 bottles of beer on the wall.
+
+51 bottles of beer on the wall, 51 bottles of beer.
+Take one down and pass it around, 50 bottles of beer on the wall.
+
+50 bottles of beer on the wall, 50 bottles of beer.
+Take one down and pass it around, 49 bottles of beer on the wall.
+
+49 bottles of beer on the wall, 49 bottles of beer.
+Take one down and pass it around, 48 bottles of beer on the wall.
+
+48 bottles of beer on the wall, 48 bottles of beer.
+Take one down and pass it around, 47 bottles of beer on the wall.
+
+47 bottles of beer on the wall, 47 bottles of beer.
+Take one down and pass it around, 46 bottles of beer on the wall.
+
+46 bottles of beer on the wall, 46 bottles of beer.
+Take one down and pass it around, 45 bottles of beer on the wall.
+
+45 bottles of beer on the wall, 45 bottles of beer.
+Take one down and pass it around, 44 bottles of beer on the wall.
+
+44 bottles of beer on the wall, 44 bottles of beer.
+Take one down and pass it around, 43 bottles of beer on the wall.
+
+43 bottles of beer on the wall, 43 bottles of beer.
+Take one down and pass it around, 42 bottles of beer on the wall.
+
+42 bottles of beer on the wall, 42 bottles of beer.
+Take one down and pass it around, 41 bottles of beer on the wall.
+
+41 bottles of beer on the wall, 41 bottles of beer.
+Take one down and pass it around, 40 bottles of beer on the wall.
+
+40 bottles of beer on the wall, 40 bottles of beer.
+Take one down and pass it around, 39 bottles of beer on the wall.
+
+39 bottles of beer on the wall, 39 bottles of beer.
+Take one down and pass it around, 38 bottles of beer on the wall.
+
+38 bottles of beer on the wall, 38 bottles of beer.
+Take one down and pass it around, 37 bottles of beer on the wall.
+
+37 bottles of beer on the wall, 37 bottles of beer.
+Take one down and pass it around, 36 bottles of beer on the wall.
+
+36 bottles of beer on the wall, 36 bottles of beer.
+Take one down and pass it around, 35 bottles of beer on the wall.
+
+35 bottles of beer on the wall, 35 bottles of beer.
+Take one down and pass it around, 34 bottles of beer on the wall.
+
+34 bottles of beer on the wall, 34 bottles of beer.
+Take one down and pass it around, 33 bottles of beer on the wall.
+
+33 bottles of beer on the wall, 33 bottles of beer.
+Take one down and pass it around, 32 bottles of beer on the wall.
+
+32 bottles of beer on the wall, 32 bottles of beer.
+Take one down and pass it around, 31 bottles of beer on the wall.
+
+31 bottles of beer on the wall, 31 bottles of beer.
+Take one down and pass it around, 30 bottles of beer on the wall.
+
+30 bottles of beer on the wall, 30 bottles of beer.
+Take one down and pass it around, 29 bottles of beer on the wall.
+
+29 bottles of beer on the wall, 29 bottles of beer.
+Take one down and pass it around, 28 bottles of beer on the wall.
+
+28 bottles of beer on the wall, 28 bottles of beer.
+Take one down and pass it around, 27 bottles of beer on the wall.
+
+27 bottles of beer on the wall, 27 bottles of beer.
+Take one down and pass it around, 26 bottles of beer on the wall.
+
+26 bottles of beer on the wall, 26 bottles of beer.
+Take one down and pass it around, 25 bottles of beer on the wall.
+
+25 bottles of beer on the wall, 25 bottles of beer.
+Take one down and pass it around, 24 bottles of beer on the wall.
+
+24 bottles of beer on the wall, 24 bottles of beer.
+Take one down and pass it around, 23 bottles of beer on the wall.
+
+23 bottles of beer on the wall, 23 bottles of beer.
+Take one down and pass it around, 22 bottles of beer on the wall.
+
+22 bottles of beer on the wall, 22 bottles of beer.
+Take one down and pass it around, 21 bottles of beer on the wall.
+
+21 bottles of beer on the wall, 21 bottles of beer.
+Take one down and pass it around, 20 bottles of beer on the wall.
+
+20 bottles of beer on the wall, 20 bottles of beer.
+Take one down and pass it around, 19 bottles of beer on the wall.
+
+19 bottles of beer on the wall, 19 bottles of beer.
+Take one down and pass it around, 18 bottles of beer on the wall.
+
+18 bottles of beer on the wall, 18 bottles of beer.
+Take one down and pass it around, 17 bottles of beer on the wall.
+
+17 bottles of beer on the wall, 17 bottles of beer.
+Take one down and pass it around, 16 bottles of beer on the wall.
+
+16 bottles of beer on the wall, 16 bottles of beer.
+Take one down and pass it around, 15 bottles of beer on the wall.
+
+15 bottles of beer on the wall, 15 bottles of beer.
+Take one down and pass it around, 14 bottles of beer on the wall.
+
+14 bottles of beer on the wall, 14 bottles of beer.
+Take one down and pass it around, 13 bottles of beer on the wall.
+
+13 bottles of beer on the wall, 13 bottles of beer.
+Take one down and pass it around, 12 bottles of beer on the wall.
+
+12 bottles of beer on the wall, 12 bottles of beer.
+Take one down and pass it around, 11 bottles of beer on the wall.
+
+11 bottles of beer on the wall, 11 bottles of beer.
+Take one down and pass it around, 10 bottles of beer on the wall.
+
+10 bottles of beer on the wall, 10 bottles of beer.
+Take one down and pass it around, 9 bottles of beer on the wall.
+
+9 bottles of beer on the wall, 9 bottles of beer.
+Take one down and pass it around, 8 bottles of beer on the wall.
+
+8 bottles of beer on the wall, 8 bottles of beer.
+Take one down and pass it around, 7 bottles of beer on the wall.
+
+7 bottles of beer on the wall, 7 bottles of beer.
+Take one down and pass it around, 6 bottles of beer on the wall.
+
+6 bottles of beer on the wall, 6 bottles of beer.
+Take one down and pass it around, 5 bottles of beer on the wall.
+
+5 bottles of beer on the wall, 5 bottles of beer.
+Take one down and pass it around, 4 bottles of beer on the wall.
+
+4 bottles of beer on the wall, 4 bottles of beer.
+Take one down and pass it around, 3 bottles of beer on the wall.
+
+3 bottles of beer on the wall, 3 bottles of beer.
+Take one down and pass it around, 2 bottles of beer on the wall.
+
+2 bottles of beer on the wall, 2 bottles of beer.
+Take one down and pass it around, 1 bottle of beer on the wall.
+
+1 bottle of beer on the wall, 1 bottle of beer.
+Take it down and pass it around, no more bottles of beer on the wall.
+
+No more bottles of beer on the wall, no more bottles of beer.
+Go to the store and buy some more, 99 bottles of beer on the wall.
+TEXT
+    assert_equal expected, BeerSong.new.verses(99, 0)
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 3, BookKeeping::VERSION
+  end
+end

--- a/exercises/binary-search-tree/README.md
+++ b/exercises/binary-search-tree/README.md
@@ -1,0 +1,84 @@
+# Binary Search Tree
+
+Insert and search for numbers in a binary tree.
+
+When we need to represent sorted data, an array does not make a good
+data structure.
+
+Say we have the array `[1, 3, 4, 5]`, and we add 2 to it so it becomes
+`[1, 3, 4, 5, 2]` now we must sort the entire array again! We can
+improve on this by realizing that we only need to make space for the new
+item `[1, nil, 3, 4, 5]`, and then adding the item in the space we
+added. But this still requires us to shift many elements down by one.
+
+Binary Search Trees, however, can operate on sorted data much more
+efficiently.
+
+A binary search tree consists of a series of connected nodes. Each node
+contains a piece of data (e.g. the number 3), a variable named `left`,
+and a variable named `right`. The `left` and `right` variables point at
+`nil`, or other nodes. Since these other nodes in turn have other nodes
+beneath them, we say that the left and right variables are pointing at
+subtrees. All data in the left subtree is less than or equal to the
+current node's data, and all data in the right subtree is greater than
+the current node's data.
+
+For example, if we had a node containing the data 4, and we added the
+data 2, our tree would look like this:
+
+      4
+     /
+    2
+
+If we then added 6, it would look like this:
+
+      4
+     / \
+    2   6
+
+If we then added 3, it would look like this
+
+       4
+     /   \
+    2     6
+     \
+      3
+
+And if we then added 1, 5, and 7, it would look like this
+
+          4
+        /   \
+       /     \
+      2       6
+     / \     / \
+    1   3   5   7
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby binary_search_tree_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride binary_search_tree_test.rb
+
+
+## Source
+
+Josh Cheek [https://twitter.com/josh_cheek](https://twitter.com/josh_cheek)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/binary-search-tree/binary_search_tree_test.rb
+++ b/exercises/binary-search-tree/binary_search_tree_test.rb
@@ -1,0 +1,123 @@
+require 'minitest/autorun'
+require_relative 'binary_search_tree'
+
+class BstTest < Minitest::Test
+  def test_data_is_retained
+    assert_equal 4, Bst.new(4).data
+  end
+
+  def test_inserting_less
+    skip
+    four = Bst.new 4
+    four.insert 2
+    assert_equal 4, four.data
+    assert_equal 2, four.left.data
+  end
+
+  def test_inserting_same
+    skip
+    four = Bst.new 4
+    four.insert 4
+    assert_equal 4, four.data
+    assert_equal 4, four.left.data
+  end
+
+  def test_inserting_right
+    skip
+    four = Bst.new 4
+    four.insert 5
+    assert_equal 4, four.data
+    assert_equal 5, four.right.data
+  end
+
+  def test_complex_tree
+    skip
+    four = Bst.new 4
+    four.insert 2
+    four.insert 6
+    four.insert 1
+    four.insert 3
+    four.insert 7
+    four.insert 5
+    assert_equal 4, four.data
+    assert_equal 2, four.left.data
+    assert_equal 1, four.left.left.data
+    assert_equal 3, four.left.right.data
+    assert_equal 6, four.right.data
+    assert_equal 5, four.right.left.data
+    assert_equal 7, four.right.right.data
+  end
+
+  def record_all_data(bst)
+    all_data = []
+    bst.each { |data| all_data << data }
+    all_data
+  end
+
+  def test_iterating_one_element
+    skip
+    assert_equal [4], record_all_data(Bst.new(4))
+  end
+
+  def test_iterating_over_smaller_element
+    skip
+    four = Bst.new 4
+    four.insert 2
+    assert_equal [2, 4], record_all_data(four)
+  end
+
+  def test_iterating_over_larger_element
+    skip
+    four = Bst.new 4
+    four.insert 5
+    assert_equal [4, 5], record_all_data(four)
+  end
+
+  def test_iterating_over_complex_tree
+    skip
+    four = Bst.new 4
+    four.insert 2
+    four.insert 1
+    four.insert 3
+    four.insert 6
+    four.insert 7
+    four.insert 5
+    assert_equal [1, 2, 3, 4, 5, 6, 7], record_all_data(four)
+  end
+
+  def test_each_returns_enumerator_if_no_block
+    skip
+
+    tree = Bst.new 4
+    [2, 1, 3, 6, 7, 5].each { |x| tree.insert x }
+    each_enumerator = tree.each
+
+    assert_kind_of Enumerator, each_enumerator
+
+    (1..7).each { |x| assert_equal(x, each_enumerator.next) }
+
+    assert_raises(StopIteration) { each_enumerator.next }
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/binary-search/README.md
+++ b/exercises/binary-search/README.md
@@ -1,0 +1,65 @@
+# Binary Search
+
+Implement a binary search algorithm.
+
+Searching a sorted collection is a common task. A dictionary is a sorted
+list of word definitions. Given a word, one can find its definition. A
+telephone book is a sorted list of people's names, addresses, and
+telephone numbers. Knowing someone's name allows one to quickly find
+their telephone number and address.
+
+If the list to be searched contains more than a few items (a dozen, say)
+a binary search will require far fewer comparisons than a linear search,
+but it imposes the requirement that the list be sorted.
+
+In computer science, a binary search or half-interval search algorithm
+finds the position of a specified input value (the search "key") within
+an array sorted by key value.
+
+In each step, the algorithm compares the search key value with the key
+value of the middle element of the array.
+
+If the keys match, then a matching element has been found and its index,
+or position, is returned.
+
+Otherwise, if the search key is less than the middle element's key, then
+the algorithm repeats its action on the sub-array to the left of the
+middle element or, if the search key is greater, on the sub-array to the
+right.
+
+If the remaining array to be searched is empty, then the key cannot be
+found in the array and a special "not found" indication is returned.
+
+A binary search halves the number of items to check with each iteration,
+so locating an item (or determining its absence) takes logarithmic time.
+A binary search is a dichotomic divide and conquer search algorithm.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby binary_search_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride binary_search_test.rb
+
+
+## Source
+
+Wikipedia [http://en.wikipedia.org/wiki/Binary_search_algorithm](http://en.wikipedia.org/wiki/Binary_search_algorithm)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/binary-search/binary_search_test.rb
+++ b/exercises/binary-search/binary_search_test.rb
@@ -1,0 +1,49 @@
+require 'minitest/autorun'
+require_relative 'binary_search'
+
+class BinarySearchTest < Minitest::Test
+  def test_it_has_list_data
+    binary = BinarySearch.new([1, 3, 4, 6, 8, 9, 11])
+    assert_equal [1, 3, 4, 6, 8, 9, 11], binary.list
+  end
+
+  def test_it_raises_error_for_unsorted_list
+    skip
+    assert_raises ArgumentError do
+      BinarySearch.new([2, 1, 4, 3, 6])
+    end
+  end
+
+  def test_it_raises_error_for_data_not_in_list
+    skip
+    assert_raises RuntimeError do
+      BinarySearch.new([1, 3, 6]).search_for(2)
+    end
+  end
+
+  def test_it_finds_position_of_middle_item
+    skip
+    binary = BinarySearch.new([1, 3, 4, 6, 8, 9, 11])
+    assert_equal 3, binary.middle
+  end
+
+  def test_it_finds_position_of_search_data
+    skip
+    binary = BinarySearch.new([1, 3, 4, 6, 8, 9, 11])
+    assert_equal 5, binary.search_for(9)
+  end
+
+  def test_it_finds_position_in_a_larger_list
+    skip
+    binary = BinarySearch.new([1, 3, 5, 8, 13, 21, 34, 55, 89, 144])
+    assert_equal 1, binary.search_for(3)
+    assert_equal 7, binary.search_for(55)
+  end
+
+  def test_it_finds_correct_position_in_a_list_with_an_even_number_of_elements
+    skip
+    binary = BinarySearch.new([1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377])
+    assert_equal 5, binary.search_for(21)
+    assert_equal 6, binary.search_for(34)
+  end
+end

--- a/exercises/binary/README.md
+++ b/exercises/binary/README.md
@@ -1,0 +1,61 @@
+# Binary
+
+Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles.
+
+Implement binary to decimal conversion. Given a binary input
+string, your program should produce a decimal output. The
+program should handle invalid inputs.
+
+## Note
+
+- Implement the conversion yourself.
+  Do not use something else to perform the conversion for you.
+
+## About Binary (Base-2)
+
+Decimal is a base-10 system.
+
+A number 23 in base 10 notation can be understood
+as a linear combination of powers of 10:
+
+- The rightmost digit gets multiplied by 10^0 = 1
+- The next number gets multiplied by 10^1 = 10
+- ...
+- The *n*th number gets multiplied by 10^*(n-1)*.
+- All these values are summed.
+
+So: `23 => 2*10^1 + 3*10^0 => 2*10 + 3*1 = 23 base 10`
+
+Binary is similar, but uses powers of 2 rather than powers of 10.
+
+So: `101 => 1*2^2 + 0*2^1 + 1*2^0 => 1*4 + 0*2 + 1*1 => 4 + 1 => 5 base 10`.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby binary_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride binary_test.rb
+
+
+## Source
+
+All of Computer Science [http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-](http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/binary/binary_test.rb
+++ b/exercises/binary/binary_test.rb
@@ -1,0 +1,102 @@
+require 'minitest/autorun'
+require_relative 'binary'
+
+# Common test data version: 1.0.0 969717d
+class BinaryTest < Minitest::Test
+  def test_binary_0_is_decimal_0
+    # skip
+    assert_equal 0, Binary.to_decimal('0')
+  end
+
+  def test_binary_1_is_decimal_1
+    skip
+    assert_equal 1, Binary.to_decimal('1')
+  end
+
+  def test_binary_10_is_decimal_2
+    skip
+    assert_equal 2, Binary.to_decimal('10')
+  end
+
+  def test_binary_11_is_decimal_3
+    skip
+    assert_equal 3, Binary.to_decimal('11')
+  end
+
+  def test_binary_100_is_decimal_4
+    skip
+    assert_equal 4, Binary.to_decimal('100')
+  end
+
+  def test_binary_1001_is_decimal_9
+    skip
+    assert_equal 9, Binary.to_decimal('1001')
+  end
+
+  def test_binary_11010_is_decimal_26
+    skip
+    assert_equal 26, Binary.to_decimal('11010')
+  end
+
+  def test_binary_10001101000_is_decimal_1128
+    skip
+    assert_equal 1128, Binary.to_decimal('10001101000')
+  end
+
+  def test_binary_ignores_leading_zeros
+    skip
+    assert_equal 31, Binary.to_decimal('000011111')
+  end
+
+  def test_2_is_not_a_valid_binary_digit
+    skip
+    assert_raises(ArgumentError) { Binary.to_decimal('2') }
+  end
+
+  def test_a_number_containing_a_non_binary_digit_is_invalid
+    skip
+    assert_raises(ArgumentError) { Binary.to_decimal('01201') }
+  end
+
+  def test_a_number_with_trailing_non_binary_characters_is_invalid
+    skip
+    assert_raises(ArgumentError) { Binary.to_decimal('10nope') }
+  end
+
+  def test_a_number_with_leading_non_binary_characters_is_invalid
+    skip
+    assert_raises(ArgumentError) { Binary.to_decimal('nope10') }
+  end
+
+  def test_a_number_with_internal_non_binary_characters_is_invalid
+    skip
+    assert_raises(ArgumentError) { Binary.to_decimal('10nope10') }
+  end
+
+  def test_a_number_and_a_word_whitespace_spearated_is_invalid
+    skip
+    assert_raises(ArgumentError) { Binary.to_decimal('001 nope') }
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 3, BookKeeping::VERSION
+  end
+end

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -1,0 +1,42 @@
+# Bob
+
+Bob is a lackadaisical teenager. In conversation, his responses are very limited.
+
+Bob answers 'Sure.' if you ask him a question.
+
+He answers 'Whoa, chill out!' if you yell at him.
+
+He says 'Fine. Be that way!' if you address him without actually saying
+anything.
+
+He answers 'Whatever.' to anything else.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby bob_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride bob_test.rb
+
+
+## Source
+
+Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial. [http://pine.fm/LearnToProgram/?Chapter=06](http://pine.fm/LearnToProgram/?Chapter=06)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/bob/bob_test.rb
+++ b/exercises/bob/bob_test.rb
@@ -1,0 +1,177 @@
+require 'minitest/autorun'
+require_relative 'bob'
+
+# Common test data version: 1.0.0 65756b1
+class BobTest < Minitest::Test
+  def test_stating_something
+    # skip
+    remark = "Tom-ay-to, tom-aaaah-to."
+    assert_equal 'Whatever.', Bob.hey(remark), %q{Bob hears "Tom-ay-to, tom-aaaah-to.", and..}
+  end
+
+  def test_shouting
+    skip
+    remark = "WATCH OUT!"
+    assert_equal 'Whoa, chill out!', Bob.hey(remark), %q{Bob hears "WATCH OUT!", and..}
+  end
+
+  def test_shouting_gibberish
+    skip
+    remark = "FCECDFCAAB"
+    assert_equal 'Whoa, chill out!', Bob.hey(remark), %q{Bob hears "FCECDFCAAB", and..}
+  end
+
+  def test_asking_a_question
+    skip
+    remark = "Does this cryogenic chamber make me look fat?"
+    assert_equal 'Sure.', Bob.hey(remark), %q{Bob hears "Does this cryogenic chamber make me look fat?", and..}
+  end
+
+  def test_asking_a_numeric_question
+    skip
+    remark = "You are, what, like 15?"
+    assert_equal 'Sure.', Bob.hey(remark), %q{Bob hears "You are, what, like 15?", and..}
+  end
+
+  def test_asking_gibberish
+    skip
+    remark = "fffbbcbeab?"
+    assert_equal 'Sure.', Bob.hey(remark), %q{Bob hears "fffbbcbeab?", and..}
+  end
+
+  def test_talking_forcefully
+    skip
+    remark = "Let's go make out behind the gym!"
+    assert_equal 'Whatever.', Bob.hey(remark), %q{Bob hears "Let's go make out behind the gym!", and..}
+  end
+
+  def test_using_acronyms_in_regular_speech
+    skip
+    remark = "It's OK if you don't want to go to the DMV."
+    assert_equal 'Whatever.', Bob.hey(remark), %q{Bob hears "It's OK if you don't want to go to the DMV.", and..}
+  end
+
+  def test_forceful_question
+    skip
+    remark = "WHAT THE HELL WERE YOU THINKING?"
+    assert_equal 'Whoa, chill out!', Bob.hey(remark), %q{Bob hears "WHAT THE HELL WERE YOU THINKING?", and..}
+  end
+
+  def test_shouting_numbers
+    skip
+    remark = "1, 2, 3 GO!"
+    assert_equal 'Whoa, chill out!', Bob.hey(remark), %q{Bob hears "1, 2, 3 GO!", and..}
+  end
+
+  def test_only_numbers
+    skip
+    remark = "1, 2, 3"
+    assert_equal 'Whatever.', Bob.hey(remark), %q{Bob hears "1, 2, 3", and..}
+  end
+
+  def test_question_with_only_numbers
+    skip
+    remark = "4?"
+    assert_equal 'Sure.', Bob.hey(remark), %q{Bob hears "4?", and..}
+  end
+
+  def test_shouting_with_special_characters
+    skip
+    remark = "ZOMG THE %^*@\#$(*^ ZOMBIES ARE COMING!!11!!1!"
+    assert_equal 'Whoa, chill out!', Bob.hey(remark), %q{Bob hears "ZOMG THE %^*@\#$(*^ ZOMBIES ARE COMING!!11!!1!", and..}
+  end
+
+  def test_shouting_with_no_exclamation_mark
+    skip
+    remark = "I HATE YOU"
+    assert_equal 'Whoa, chill out!', Bob.hey(remark), %q{Bob hears "I HATE YOU", and..}
+  end
+
+  def test_statement_containing_question_mark
+    skip
+    remark = "Ending with ? means a question."
+    assert_equal 'Whatever.', Bob.hey(remark), %q{Bob hears "Ending with ? means a question.", and..}
+  end
+
+  def test_non_letters_with_question
+    skip
+    remark = ":) ?"
+    assert_equal 'Sure.', Bob.hey(remark), %q{Bob hears ":) ?", and..}
+  end
+
+  def test_prattling_on
+    skip
+    remark = "Wait! Hang on. Are you going to be OK?"
+    assert_equal 'Sure.', Bob.hey(remark), %q{Bob hears "Wait! Hang on. Are you going to be OK?", and..}
+  end
+
+  def test_silence
+    skip
+    remark = ""
+    assert_equal 'Fine. Be that way!', Bob.hey(remark), %q{Bob hears "", and..}
+  end
+
+  def test_prolonged_silence
+    skip
+    remark = "          "
+    assert_equal 'Fine. Be that way!', Bob.hey(remark), %q{Bob hears "          ", and..}
+  end
+
+  def test_alternate_silence
+    skip
+    remark = "\t\t\t\t\t\t\t\t\t\t"
+    assert_equal 'Fine. Be that way!', Bob.hey(remark), %q{Bob hears "\t\t\t\t\t\t\t\t\t\t", and..}
+  end
+
+  def test_multiple_line_question
+    skip
+    remark = "\nDoes this cryogenic chamber make me look fat?\nno"
+    assert_equal 'Whatever.', Bob.hey(remark), %q{Bob hears "\nDoes this cryogenic chamber make me look fat?\nno", and..}
+  end
+
+  def test_starting_with_whitespace
+    skip
+    remark = "         hmmmmmmm..."
+    assert_equal 'Whatever.', Bob.hey(remark), %q{Bob hears "         hmmmmmmm...", and..}
+  end
+
+  def test_ending_with_whitespace
+    skip
+    remark = "Okay if like my  spacebar  quite a bit?   "
+    assert_equal 'Sure.', Bob.hey(remark), %q{Bob hears "Okay if like my  spacebar  quite a bit?   ", and..}
+  end
+
+  def test_other_whitespace
+    skip
+    remark = "\n\r \t"
+    assert_equal 'Fine. Be that way!', Bob.hey(remark), %q{Bob hears "\n\r \t", and..}
+  end
+
+  def test_non_question_ending_with_whitespace
+    skip
+    remark = "This is a statement ending with whitespace      "
+    assert_equal 'Whatever.', Bob.hey(remark), %q{Bob hears "This is a statement ending with whitespace      ", and..}
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/book-store/README.md
+++ b/exercises/book-store/README.md
@@ -1,0 +1,98 @@
+# Book Store
+
+To try and encourage more sales of different books from a popular 5 book
+series, a bookshop has decided to offer discounts on multiple book purchases.
+
+One copy of any of the five books costs $8.
+
+If, however, you buy two different books, you get a 5%
+discount on those two books.
+
+If you buy 3 different books, you get a 10% discount.
+
+If you buy 4 different books, you get a 20% discount.
+
+If you buy all 5, you get a 25% discount.
+
+Note: that if you buy four books, of which 3 are
+different titles, you get a 10% discount on the 3 that
+form part of a set, but the fourth book still costs $8.
+
+Your mission is to write a piece of code to calculate the
+price of any conceivable shopping basket (containing only
+books of the same series), giving as big a discount as
+possible.
+
+For example, how much does this basket of books cost?
+
+- 2 copies of the first book
+- 2 copies of the second book
+- 2 copies of the third book
+- 1 copy of the fourth book
+- 1 copy of the fifth book
+
+One way of grouping these 8 books is:
+
+- 1 group of 5 --> 25% discount (1st,2nd,3rd,4th,5th)
+- +1 group of 3 --> 10% discount (1st,2nd,3rd)
+
+This would give a total of:
+
+- 5 books at a 25% discount
+- +3 books at a 10% discount
+
+Resulting in:
+
+- 5 x (8 - 2.00) == 5 x 6.00 == $30.00
+- +3 x (8 - 0.80) == 3 x 7.20 == $21.60
+
+For a total of $51.60
+
+However, a different way to group these 8 books is:
+
+- 1 group of 4 books --> 20% discount  (1st,2nd,3rd,4th)
+- +1 group of 4 books --> 20% discount  (1st,2nd,3rd,5th)
+
+This would give a total of:
+
+- 4 books at a 20% discount
+- +4 books at a 20% discount
+
+Resulting in:
+
+- 4 x (8 - 1.60) == 4 x 6.40 == $25.60
+- +4 x (8 - 1.60) == 4 x 6.40 == $25.60
+
+For a total of $51.20
+
+And $51.20 is the price with the biggest discount.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby book_store_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride book_store_test.rb
+
+
+## Source
+
+Inspired by the harry potter kata from Cyber-Dojo. [http://cyber-dojo.org](http://cyber-dojo.org)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/book-store/book_store_test.rb
+++ b/exercises/book-store/book_store_test.rb
@@ -1,0 +1,97 @@
+require 'minitest/autorun'
+require_relative 'book_store'
+
+# Common test data version: 1.1.0 a636903
+class BookStoreTest < Minitest::Test
+  def test_only_a_single_book
+    # skip
+    assert_equal 8.0, BookStore.calculate_price([1])
+  end
+
+  def test_two_of_the_same_book
+    skip
+    assert_equal 16.0, BookStore.calculate_price([2, 2])
+  end
+
+  def test_empty_basket
+    skip
+    assert_equal 0.0, BookStore.calculate_price([])
+  end
+
+  def test_two_different_books
+    skip
+    assert_equal 15.2, BookStore.calculate_price([1, 2])
+  end
+
+  def test_three_different_books
+    skip
+    assert_equal 21.6, BookStore.calculate_price([1, 2, 3])
+  end
+
+  def test_four_different_books
+    skip
+    assert_equal 25.6, BookStore.calculate_price([1, 2, 3, 4])
+  end
+
+  def test_five_different_books
+    skip
+    assert_equal 30.0, BookStore.calculate_price([1, 2, 3, 4, 5])
+  end
+
+  def test_two_groups_of_four_is_cheaper_than_group_of_five_plus_group_of_three
+    skip
+    assert_equal 51.2, BookStore.calculate_price([1, 1, 2, 2, 3, 3, 4, 5])
+  end
+
+  def test_group_of_four_plus_group_of_two_is_cheaper_than_two_groups_of_three
+    skip
+    assert_equal 40.8, BookStore.calculate_price([1, 1, 2, 2, 3, 4])
+  end
+
+  def test_two_each_of_first_4_books_and_1_copy_each_of_rest
+    skip
+    assert_equal 55.6, BookStore.calculate_price([1, 1, 2, 2, 3, 3, 4, 4, 5])
+  end
+
+  def test_two_copies_of_each_book
+    skip
+    assert_equal 60.0, BookStore.calculate_price([1, 1, 2, 2, 3, 3, 4, 4, 5, 5])
+  end
+
+  def test_three_copies_of_first_book_and_2_each_of_remaining
+    skip
+    assert_equal 68.0, BookStore.calculate_price([1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 1])
+  end
+
+  def test_three_each_of_first_2_books_and_2_each_of_remaining_books
+    skip
+    assert_equal 75.2, BookStore.calculate_price([1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 1, 2])
+  end
+
+  def test_four_groups_of_four_are_cheaper_than_two_groups_each_of_five_and_three
+    skip
+    assert_equal 102.4, BookStore.calculate_price([1, 1, 2, 2, 3, 3, 4, 5, 1, 1, 2, 2, 3, 3, 4, 5])
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 0, BookKeeping::VERSION
+  end
+end

--- a/exercises/bowling/README.md
+++ b/exercises/bowling/README.md
@@ -1,0 +1,91 @@
+# Bowling
+
+Score a bowling game.
+
+Bowling is a game where players roll a heavy ball to knock down pins
+arranged in a triangle. Write code to keep track of the score
+of a game of bowling.
+
+## Scoring Bowling
+
+The game consists of 10 frames. A frame is composed of one or two ball
+throws with 10 pins standing at frame initialization. There are three
+cases for the tabulation of a frame.
+
+* An open frame is where a score of less than 10 is recorded for the
+  frame. In this case the score for the frame is the number of pins
+  knocked down.
+
+* A spare is where all ten pins are knocked down by the second
+  throw. The total value of a spare is 10 plus the number of pins
+  knocked down in their next throw.
+
+* A strike is where all ten pins are knocked down by the first
+  throw. The total value of a strike is 10 plus the number of pins
+  knocked down in the next two throws. If a strike is immediately
+  followed by a second strike, then the value of the first strike
+  cannot be determined until the ball is thrown one more time.
+
+Here is a three frame example:
+
+| Frame 1         | Frame 2       | Frame 3                |
+| :-------------: |:-------------:| :---------------------:|
+| X (strike)      | 5/ (spare)    | 9 0 (open frame)       |
+
+Frame 1 is (10 + 5 + 5) = 20
+
+Frame 2 is (5 + 5 + 9) = 19
+
+Frame 3 is (9 + 0) = 9
+
+This means the current running total is 48.
+
+The tenth frame in the game is a special case. If someone throws a
+strike or a spare then they get a fill ball. Fill balls exist to
+calculate the total of the 10th frame. Scoring a strike or spare on
+the fill ball does not give the player more fill balls. The total
+value of the 10th frame is the total number of pins knocked down.
+
+For a tenth frame of X1/ (strike and a spare), the total value is 20.
+
+For a tenth frame of XXX (three strikes), the total value is 30.
+
+## Requirements
+
+Write code to keep track of the score of a game of bowling. It should
+support two operations:
+
+* `roll(pins : int)` is called each time the player rolls a ball.  The
+  argument is the number of pins knocked down.
+* `score() : int` is called only at the very end of the game.  It
+  returns the total score for that game.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby bowling_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride bowling_test.rb
+
+
+## Source
+
+The Bowling Game Kata at but UncleBob [http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata](http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/bowling/bowling_test.rb
+++ b/exercises/bowling/bowling_test.rb
@@ -1,0 +1,228 @@
+require 'minitest/autorun'
+require_relative 'bowling'
+
+# Common test data version: 1.0.1 26e345e
+class BowlingTest < Minitest::Test
+  def setup
+    @game = Game.new
+  end
+
+  def record(rolls)
+    rolls.each { |pins| @game.roll(pins) }
+  end
+
+  def test_should_be_able_to_score_a_game_with_all_zeros
+    # skip
+    record([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    assert_equal 0, @game.score
+  end
+
+  def test_should_be_able_to_score_a_game_with_no_strikes_or_spares
+    skip
+    record([3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6])
+    assert_equal 90, @game.score
+  end
+
+  def test_a_spare_followed_by_zeros_is_worth_ten_points
+    skip
+    record([6, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    assert_equal 10, @game.score
+  end
+
+  def test_points_scored_in_the_roll_after_a_spare_are_counted_twice
+    skip
+    record([6, 4, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    assert_equal 16, @game.score
+  end
+
+  def test_consecutive_spares_each_get_a_one_roll_bonus
+    skip
+    record([5, 5, 3, 7, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    assert_equal 31, @game.score
+  end
+
+  def test_a_spare_in_the_last_frame_gets_a_one_roll_bonus_that_is_counted_once
+    skip
+    record([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 7])
+    assert_equal 17, @game.score
+  end
+
+  def test_a_strike_earns_ten_points_in_a_frame_with_a_single_roll
+    skip
+    record([10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    assert_equal 10, @game.score
+  end
+
+  def test_points_scored_in_the_two_rolls_after_a_strike_are_counted_twice_as_a_bonus
+    skip
+    record([10, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    assert_equal 26, @game.score
+  end
+
+  def test_consecutive_strikes_each_get_the_two_roll_bonus
+    skip
+    record([10, 10, 10, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    assert_equal 81, @game.score
+  end
+
+  def test_a_strike_in_the_last_frame_gets_a_two_roll_bonus_that_is_counted_once
+    skip
+    record([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 7, 1])
+    assert_equal 18, @game.score
+  end
+
+  def test_rolling_a_spare_with_the_two_roll_bonus_does_not_get_a_bonus_roll
+    skip
+    record([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 7, 3])
+    assert_equal 20, @game.score
+  end
+
+  def test_strikes_with_the_two_roll_bonus_do_not_get_bonus_rolls
+    skip
+    record([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 10])
+    assert_equal 30, @game.score
+  end
+
+  def test_a_strike_with_the_one_roll_bonus_after_a_spare_in_the_last_frame_does_not_get_a_bonus
+    skip
+    record([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 10])
+    assert_equal 20, @game.score
+  end
+
+  def test_all_strikes_is_a_perfect_game
+    skip
+    record([10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10])
+    assert_equal 300, @game.score
+  end
+
+  def test_rolls_cannot_score_negative_points
+    skip
+    record([])
+    assert_raises Game::BowlingError do
+      @game.roll(-1)
+    end
+  end
+
+  def test_a_roll_cannot_score_more_than_10_points
+    skip
+    record([])
+    assert_raises Game::BowlingError do
+      @game.roll(11)
+    end
+  end
+
+  def test_two_rolls_in_a_frame_cannot_score_more_than_10_points
+    skip
+    record([5])
+    assert_raises Game::BowlingError do
+      @game.roll(6)
+    end
+  end
+
+  def test_bonus_roll_after_a_strike_in_the_last_frame_cannot_score_more_than_10_points
+    skip
+    record([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10])
+    assert_raises Game::BowlingError do
+      @game.roll(11)
+    end
+  end
+
+  def test_two_bonus_rolls_after_a_strike_in_the_last_frame_cannot_score_more_than_10_points
+    skip
+    record([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 5])
+    assert_raises Game::BowlingError do
+      @game.roll(6)
+    end
+  end
+
+  def test_two_bonus_rolls_after_a_strike_in_the_last_frame_can_score_more_than_10_points_if_one_is_a_strike
+    skip
+    record([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 6])
+    assert_equal 26, @game.score
+  end
+
+  def test_the_second_bonus_rolls_after_a_strike_in_the_last_frame_cannot_be_a_strike_if_the_first_one_is_not_a_strike
+    skip
+    record([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 6])
+    assert_raises Game::BowlingError do
+      @game.roll(10)
+    end
+  end
+
+  def test_second_bonus_roll_after_a_strike_in_the_last_frame_cannot_score_more_than_10_points
+    skip
+    record([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10])
+    assert_raises Game::BowlingError do
+      @game.roll(11)
+    end
+  end
+
+  def test_an_unstarted_game_cannot_be_scored
+    skip
+    record([])
+    assert_raises Game::BowlingError do
+      @game.score
+    end
+  end
+
+  def test_an_incomplete_game_cannot_be_scored
+    skip
+    record([0, 0])
+    assert_raises Game::BowlingError do
+      @game.score
+    end
+  end
+
+  def test_cannot_roll_if_game_already_has_ten_frames
+    skip
+    record([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    assert_raises Game::BowlingError do
+      @game.roll(0)
+    end
+  end
+
+  def test_bonus_rolls_for_a_strike_in_the_last_frame_must_be_rolled_before_score_can_be_calculated
+    skip
+    record([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10])
+    assert_raises Game::BowlingError do
+      @game.score
+    end
+  end
+
+  def test_both_bonus_rolls_for_a_strike_in_the_last_frame_must_be_rolled_before_score_can_be_calculated
+    skip
+    record([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10])
+    assert_raises Game::BowlingError do
+      @game.score
+    end
+  end
+
+  def test_bonus_roll_for_a_spare_in_the_last_frame_must_be_rolled_before_score_can_be_calculated
+    skip
+    record([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3])
+    assert_raises Game::BowlingError do
+      @game.score
+    end
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+  def test_bookkeeping
+    skip
+    assert_equal 3, BookKeeping::VERSION
+  end
+end

--- a/exercises/bracket-push/README.md
+++ b/exercises/bracket-push/README.md
@@ -1,0 +1,34 @@
+# Bracket Push
+
+Given a string containing brackets `[]`, braces `{}` and parentheses `()`,
+verify that all the pairs are matched and nested correctly.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby bracket_push_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride bracket_push_test.rb
+
+
+## Source
+
+Ginna Baker
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/bracket-push/bracket_push_test.rb
+++ b/exercises/bracket-push/bracket_push_test.rb
@@ -1,0 +1,99 @@
+require 'minitest/autorun'
+require_relative 'bracket_push'
+
+# Common test data version: 1.1.0 855c591
+class BracketPushTest < Minitest::Test
+  def test_paired_square_brackets
+    # skip
+    assert Brackets.paired?('[]')
+  end
+
+  def test_empty_string
+    skip
+    assert Brackets.paired?('')
+  end
+
+  def test_unpaired_brackets
+    skip
+    refute Brackets.paired?('[[')
+  end
+
+  def test_wrong_ordered_brackets
+    skip
+    refute Brackets.paired?('}{')
+  end
+
+  def test_wrong_closing_bracket
+    skip
+    refute Brackets.paired?('{]')
+  end
+
+  def test_paired_with_whitespace
+    skip
+    assert Brackets.paired?('{ }')
+  end
+
+  def test_simple_nested_brackets
+    skip
+    assert Brackets.paired?('{[]}')
+  end
+
+  def test_several_paired_brackets
+    skip
+    assert Brackets.paired?('{}[]')
+  end
+
+  def test_paired_and_nested_brackets
+    skip
+    assert Brackets.paired?('([{}({}[])])')
+  end
+
+  def test_unopened_closing_brackets
+    skip
+    refute Brackets.paired?('{[)][]}')
+  end
+
+  def test_unpaired_and_nested_brackets
+    skip
+    refute Brackets.paired?('([{])')
+  end
+
+  def test_paired_and_wrong_nested_brackets
+    skip
+    refute Brackets.paired?('[({]})')
+  end
+
+  def test_math_expression
+    skip
+    assert Brackets.paired?('(((185 + 223.85) * 15) - 543)/2')
+  end
+
+  def test_complex_latex_expression
+    skip
+    str = '\left(\begin{array}{cc} \frac{1}{3} & x\\ '\
+          '\mathrm{e}^{x} &... x^2 \end{array}\right)'
+    assert Brackets.paired?(str)
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 4, BookKeeping::VERSION
+  end
+end

--- a/exercises/change/README.md
+++ b/exercises/change/README.md
@@ -1,0 +1,47 @@
+# Change
+
+Correctly determine the fewest number of coins to be given to a customer such
+that the sum of the coins' value would equal the correct amount of change.
+
+## For example
+
+- An input of 15 with [1, 5, 10, 25, 100] should return one nickel (5)
+  and one dime (10) or [0, 1, 1, 0, 0]
+- An input of 40 with [1, 5, 10, 25, 100] should return one nickel (5)
+  and one dime (10) and one quarter (25) or [0, 1, 1, 1, 0]
+
+## Edge cases
+
+- Does your algorithm work for any given set of coins?
+- Can you ask for negative change?
+- Can you ask for a change value smaller than the smallest coin value?
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby change_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride change_test.rb
+
+
+## Source
+
+Software Craftsmanship - Coin Change Kata [https://web.archive.org/web/20130115115225/http://craftsmanship.sv.cmu.edu:80/exercises/coin-change-kata](https://web.archive.org/web/20130115115225/http://craftsmanship.sv.cmu.edu:80/exercises/coin-change-kata)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/change/change_test.rb
+++ b/exercises/change/change_test.rb
@@ -1,0 +1,82 @@
+require 'minitest/autorun'
+require_relative 'change'
+
+# Common test data version: 1.1.0 52cf1cf
+class ChangeTest < Minitest::Test
+  def test_single_coin_change
+    # skip
+    assert_equal [25], Change.generate([1, 5, 10, 25, 100], 25)
+  end
+
+  def test_multiple_coin_change
+    skip
+    assert_equal [5, 10], Change.generate([1, 5, 10, 25, 100], 15)
+  end
+
+  def test_change_with_lilliputian_coins
+    skip
+    assert_equal [4, 4, 15], Change.generate([1, 4, 15, 20, 50], 23)
+  end
+
+  def test_change_with_lower_elbonia_coins
+    skip
+    assert_equal [21, 21, 21], Change.generate([1, 5, 10, 21, 25], 63)
+  end
+
+  def test_large_target_values
+    skip
+    assert_equal [2, 2, 5, 20, 20, 50, 100, 100, 100, 100, 100, 100, 100, 100, 100], Change.generate([1, 2, 5, 10, 20, 50, 100], 999)
+  end
+
+  def test_possible_change_without_unit_coins_available
+    skip
+    assert_equal [2, 2, 2, 5, 10], Change.generate([2, 5, 10, 20, 50], 21)
+  end
+
+  def test_another_possible_change_without_unit_coins_available
+    skip
+    assert_equal [4, 4, 4, 5, 5, 5], Change.generate([4, 5], 27)
+  end
+
+  def test_no_coins_make_0_change
+    skip
+    assert_equal [], Change.generate([1, 5, 10, 21, 25], 0)
+  end
+
+  def test_error_testing_for_change_smaller_than_the_smallest_of_coins
+    skip
+    assert_equal -1, Change.generate([5, 10], 3)
+  end
+
+  def test_error_if_no_combination_can_add_up_to_target
+    skip
+    assert_equal -1, Change.generate([5, 10], 94)
+  end
+
+  def test_cannot_find_negative_change_values
+    skip
+    assert_equal -1, Change.generate([1, 2, 5], -5)
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 2, BookKeeping::VERSION
+  end
+end

--- a/exercises/circular-buffer/README.md
+++ b/exercises/circular-buffer/README.md
@@ -1,0 +1,81 @@
+# Circular Buffer
+
+A circular buffer, cyclic buffer or ring buffer is a data structure that
+uses a single, fixed-size buffer as if it were connected end-to-end.
+
+A circular buffer first starts empty and of some predefined length. For
+example, this is a 7-element buffer:
+
+    [ ][ ][ ][ ][ ][ ][ ]
+
+Assume that a 1 is written into the middle of the buffer (exact starting
+location does not matter in a circular buffer):
+
+    [ ][ ][ ][1][ ][ ][ ]
+
+Then assume that two more elements are added — 2 & 3 — which get
+appended after the 1:
+
+    [ ][ ][ ][1][2][3][ ]
+
+If two elements are then removed from the buffer, the oldest values
+inside the buffer are removed. The two elements removed, in this case,
+are 1 & 2, leaving the buffer with just a 3:
+
+    [ ][ ][ ][ ][ ][3][ ]
+
+If the buffer has 7 elements then it is completely full:
+
+    [6][7][8][9][3][4][5]
+
+When the buffer is full an error will be raised, alerting the client
+that further writes are blocked until a slot becomes free.
+
+When the buffer is full, the client can opt to overwrite the oldest
+data with a forced write. In this case, two more elements — A & B —
+are added and they overwrite the 3 & 4:
+
+    [6][7][8][9][A][B][5]
+
+3 & 4 have been replaced by A & B making 5 now the oldest data in the
+buffer. Finally, if two elements are removed then what would be
+returned is 5 & 6 yielding the buffer:
+
+    [ ][7][8][9][A][B][ ]
+
+Because there is space available, if the client again uses overwrite
+to store C & D then the space where 5 & 6 were stored previously will
+be used not the location of 7 & 8. 7 is still the oldest element and
+the buffer is once again full.
+
+    [D][7][8][9][A][B][C]
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby circular_buffer_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride circular_buffer_test.rb
+
+
+## Source
+
+Wikipedia [http://en.wikipedia.org/wiki/Circular_buffer](http://en.wikipedia.org/wiki/Circular_buffer)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/circular-buffer/circular_buffer_test.rb
+++ b/exercises/circular-buffer/circular_buffer_test.rb
@@ -1,0 +1,108 @@
+require 'minitest/autorun'
+require_relative 'circular_buffer'
+
+class CircularBufferTest < Minitest::Test
+  def test_read_empty_buffer_throws_buffer_empty_exception
+    buffer = CircularBuffer.new(1)
+    assert_raises(CircularBuffer::BufferEmptyException) { buffer.read }
+  end
+
+  def test_write_and_read_back_one_item
+    skip
+    buffer = CircularBuffer.new(1)
+    buffer.write '1'
+    assert_equal '1', buffer.read
+    assert_raises(CircularBuffer::BufferEmptyException) { buffer.read }
+  end
+
+  def test_write_and_read_back_multiple_items
+    skip
+    buffer = CircularBuffer.new(2)
+    buffer.write '1'
+    buffer.write '2'
+    assert_equal '1', buffer.read
+    assert_equal '2', buffer.read
+    assert_raises(CircularBuffer::BufferEmptyException) { buffer.read }
+  end
+
+  def test_clearing_buffer
+    skip
+    buffer = CircularBuffer.new(3)
+    ('1'..'3').each { |i| buffer.write i }
+    buffer.clear
+    assert_raises(CircularBuffer::BufferEmptyException) { buffer.read }
+    buffer.write '1'
+    buffer.write '2'
+    assert_equal '1', buffer.read
+    buffer.write '3'
+    assert_equal '2', buffer.read
+  end
+
+  def test_alternate_write_and_read
+    skip
+    buffer = CircularBuffer.new(2)
+    buffer.write '1'
+    assert_equal '1', buffer.read
+    buffer.write '2'
+    assert_equal '2', buffer.read
+  end
+
+  def test_reads_back_oldest_item
+    skip
+    buffer = CircularBuffer.new(3)
+    buffer.write '1'
+    buffer.write '2'
+    buffer.read
+    buffer.write '3'
+    assert_equal '2', buffer.read
+    assert_equal '3', buffer.read
+  end
+
+  def test_writing_to_a_full_buffer_throws_an_exception
+    skip
+    buffer = CircularBuffer.new(2)
+    buffer.write '1'
+    buffer.write '2'
+    assert_raises(CircularBuffer::BufferFullException) { buffer.write 'A' }
+  end
+
+  def test_overwriting_oldest_item_in_a_full_buffer
+    skip
+    buffer = CircularBuffer.new(2)
+    buffer.write '1'
+    buffer.write '2'
+    buffer.write! 'A'
+    assert_equal '2', buffer.read
+    assert_equal 'A', buffer.read
+    assert_raises(CircularBuffer::BufferEmptyException) { buffer.read }
+  end
+
+  def test_forced_writes_to_non_full_buffer_should_behave_like_writes
+    skip
+    buffer = CircularBuffer.new(2)
+    buffer.write '1'
+    buffer.write! '2'
+    assert_equal '1', buffer.read
+    assert_equal '2', buffer.read
+    assert_raises(CircularBuffer::BufferEmptyException) { buffer.read }
+  end
+
+  def test_alternate_read_and_write_into_buffer_overflow
+    skip
+    buffer = CircularBuffer.new(5)
+    ('1'..'3').each { |i| buffer.write i }
+    buffer.read
+    buffer.read
+    buffer.write '4'
+    buffer.read
+    ('5'..'8').each { |i| buffer.write i }
+    buffer.write! 'A'
+    buffer.write! 'B'
+    ('6'..'8').each do |i|
+      assert_equal i, buffer.read
+    end
+    assert_equal 'A', buffer.read
+    assert_equal 'B', buffer.read
+    assert_raises(CircularBuffer::BufferEmptyException) { buffer.read }
+  end
+end

--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -1,0 +1,37 @@
+# Clock
+
+Implement a clock that handles times without dates.
+
+You should be able to add and subtract minutes to it.
+
+Two clocks that represent the same time should be equal to each other.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby clock_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride clock_test.rb
+
+
+## Source
+
+Pairing session with Erin Drummond [https://twitter.com/ebdrummond](https://twitter.com/ebdrummond)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/clock/clock_test.rb
+++ b/exercises/clock/clock_test.rb
@@ -1,0 +1,307 @@
+require 'minitest/autorun'
+require_relative 'clock'
+
+# Common test data version: 1.0.1 54c3b74
+class ClockTest < Minitest::Test
+  def test_on_the_hour
+    # skip
+    assert_equal "08:00", Clock.at(8, 0).to_s
+  end
+
+  def test_past_the_hour
+    skip
+    assert_equal "11:09", Clock.at(11, 9).to_s
+  end
+
+  def test_midnight_is_zero_hours
+    skip
+    assert_equal "00:00", Clock.at(24, 0).to_s
+  end
+
+  def test_hour_rolls_over
+    skip
+    assert_equal "01:00", Clock.at(25, 0).to_s
+  end
+
+  def test_hour_rolls_over_continuously
+    skip
+    assert_equal "04:00", Clock.at(100, 0).to_s
+  end
+
+  def test_sixty_minutes_is_next_hour
+    skip
+    assert_equal "02:00", Clock.at(1, 60).to_s
+  end
+
+  def test_minutes_roll_over
+    skip
+    assert_equal "02:40", Clock.at(0, 160).to_s
+  end
+
+  def test_minutes_roll_over_continuously
+    skip
+    assert_equal "04:43", Clock.at(0, 1723).to_s
+  end
+
+  def test_hour_and_minutes_roll_over
+    skip
+    assert_equal "03:40", Clock.at(25, 160).to_s
+  end
+
+  def test_hour_and_minutes_roll_over_continuously
+    skip
+    assert_equal "11:01", Clock.at(201, 3001).to_s
+  end
+
+  def test_hour_and_minutes_roll_over_to_exactly_midnight
+    skip
+    assert_equal "00:00", Clock.at(72, 8640).to_s
+  end
+
+  def test_negative_hour
+    skip
+    assert_equal "23:15", Clock.at(-1, 15).to_s
+  end
+
+  def test_negative_hour_rolls_over
+    skip
+    assert_equal "23:00", Clock.at(-25, 0).to_s
+  end
+
+  def test_negative_hour_rolls_over_continuously
+    skip
+    assert_equal "05:00", Clock.at(-91, 0).to_s
+  end
+
+  def test_negative_minutes
+    skip
+    assert_equal "00:20", Clock.at(1, -40).to_s
+  end
+
+  def test_negative_minutes_roll_over
+    skip
+    assert_equal "22:20", Clock.at(1, -160).to_s
+  end
+
+  def test_negative_minutes_roll_over_continuously
+    skip
+    assert_equal "16:40", Clock.at(1, -4820).to_s
+  end
+
+  def test_negative_hour_and_minutes_both_roll_over
+    skip
+    assert_equal "20:20", Clock.at(-25, -160).to_s
+  end
+
+  def test_negative_hour_and_minutes_both_roll_over_continuously
+    skip
+    assert_equal "22:10", Clock.at(-121, -5810).to_s
+  end
+
+  def test_add_minutes
+    skip
+    assert_equal "10:03", (Clock.at(10, 0) + 3).to_s
+  end
+
+  def test_add_no_minutes
+    skip
+    assert_equal "06:41", (Clock.at(6, 41) + 0).to_s
+  end
+
+  def test_add_to_next_hour
+    skip
+    assert_equal "01:25", (Clock.at(0, 45) + 40).to_s
+  end
+
+  def test_add_more_than_one_hour
+    skip
+    assert_equal "11:01", (Clock.at(10, 0) + 61).to_s
+  end
+
+  def test_add_more_than_two_hours_with_carry
+    skip
+    assert_equal "03:25", (Clock.at(0, 45) + 160).to_s
+  end
+
+  def test_add_across_midnight
+    skip
+    assert_equal "00:01", (Clock.at(23, 59) + 2).to_s
+  end
+
+  def test_add_more_than_one_day__1500_min_is_equal_to_25_hrs
+    skip
+    assert_equal "06:32", (Clock.at(5, 32) + 1500).to_s
+  end
+
+  def test_add_more_than_two_days
+    skip
+    assert_equal "11:21", (Clock.at(1, 1) + 3500).to_s
+  end
+
+  def test_subtract_minutes
+    skip
+    assert_equal "10:00", (Clock.at(10, 3) + -3).to_s
+  end
+
+  def test_subtract_to_previous_hour
+    skip
+    assert_equal "09:33", (Clock.at(10, 3) + -30).to_s
+  end
+
+  def test_subtract_more_than_an_hour
+    skip
+    assert_equal "08:53", (Clock.at(10, 3) + -70).to_s
+  end
+
+  def test_subtract_across_midnight
+    skip
+    assert_equal "23:59", (Clock.at(0, 3) + -4).to_s
+  end
+
+  def test_subtract_more_than_two_hours
+    skip
+    assert_equal "21:20", (Clock.at(0, 0) + -160).to_s
+  end
+
+  def test_subtract_more_than_two_hours_with_borrow
+    skip
+    assert_equal "03:35", (Clock.at(6, 15) + -160).to_s
+  end
+
+  def test_subtract_more_than_one_day__1500_min_is_equal_to_25_hrs
+    skip
+    assert_equal "04:32", (Clock.at(5, 32) + -1500).to_s
+  end
+
+  def test_subtract_more_than_two_days
+    skip
+    assert_equal "00:20", (Clock.at(2, 20) + -3000).to_s
+  end
+
+  def test_clocks_with_same_time
+    skip
+    clock1 = Clock.at(15, 37)
+    clock2 = Clock.at(15, 37)
+    assert clock1 == clock2
+  end
+
+  def test_clocks_a_minute_apart
+    skip
+    clock1 = Clock.at(15, 36)
+    clock2 = Clock.at(15, 37)
+    refute clock1 == clock2
+  end
+
+  def test_clocks_an_hour_apart
+    skip
+    clock1 = Clock.at(14, 37)
+    clock2 = Clock.at(15, 37)
+    refute clock1 == clock2
+  end
+
+  def test_clocks_with_hour_overflow
+    skip
+    clock1 = Clock.at(10, 37)
+    clock2 = Clock.at(34, 37)
+    assert clock1 == clock2
+  end
+
+  def test_clocks_with_hour_overflow_by_several_days
+    skip
+    clock1 = Clock.at(3, 11)
+    clock2 = Clock.at(99, 11)
+    assert clock1 == clock2
+  end
+
+  def test_clocks_with_negative_hour
+    skip
+    clock1 = Clock.at(22, 40)
+    clock2 = Clock.at(-2, 40)
+    assert clock1 == clock2
+  end
+
+  def test_clocks_with_negative_hour_that_wraps
+    skip
+    clock1 = Clock.at(17, 3)
+    clock2 = Clock.at(-31, 3)
+    assert clock1 == clock2
+  end
+
+  def test_clocks_with_negative_hour_that_wraps_multiple_times
+    skip
+    clock1 = Clock.at(13, 49)
+    clock2 = Clock.at(-83, 49)
+    assert clock1 == clock2
+  end
+
+  def test_clocks_with_minute_overflow
+    skip
+    clock1 = Clock.at(0, 1)
+    clock2 = Clock.at(0, 1441)
+    assert clock1 == clock2
+  end
+
+  def test_clocks_with_minute_overflow_by_several_days
+    skip
+    clock1 = Clock.at(2, 2)
+    clock2 = Clock.at(2, 4322)
+    assert clock1 == clock2
+  end
+
+  def test_clocks_with_negative_minute
+    skip
+    clock1 = Clock.at(2, 40)
+    clock2 = Clock.at(3, -20)
+    assert clock1 == clock2
+  end
+
+  def test_clocks_with_negative_minute_that_wraps
+    skip
+    clock1 = Clock.at(4, 10)
+    clock2 = Clock.at(5, -1490)
+    assert clock1 == clock2
+  end
+
+  def test_clocks_with_negative_minute_that_wraps_multiple_times
+    skip
+    clock1 = Clock.at(6, 15)
+    clock2 = Clock.at(6, -4305)
+    assert clock1 == clock2
+  end
+
+  def test_clocks_with_negative_hours_and_minutes
+    skip
+    clock1 = Clock.at(7, 32)
+    clock2 = Clock.at(-12, -268)
+    assert clock1 == clock2
+  end
+
+  def test_clocks_with_negative_hours_and_minutes_that_wrap
+    skip
+    clock1 = Clock.at(18, 7)
+    clock2 = Clock.at(-54, -11513)
+    assert clock1 == clock2
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 2, BookKeeping::VERSION
+  end
+end

--- a/exercises/collatz-conjecture/README.md
+++ b/exercises/collatz-conjecture/README.md
@@ -1,0 +1,57 @@
+# Collatz Conjecture
+
+The Collatz Conjecture or 3x+1 problem can be summarized as follows:
+
+Take any positive integer n. If n is even, divide n by 2 to get n / 2. If n is
+odd, multiply n by 3 and add 1 to get 3n + 1. Repeat the process indefinitely.
+The conjecture states that no matter which number you start with, you will
+always reach 1 eventually.
+
+Given a number n, return the number of steps required to reach 1.
+
+## Examples
+
+Starting with n = 12, the steps would be as follows:
+
+0. 12
+1. 6
+2. 3
+3. 10
+4. 5
+5. 16
+6. 8
+7. 4
+8. 2
+9. 1
+
+Resulting in 9 steps. So for input n = 12, the return value would be 9.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby collatz_conjecture_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride collatz_conjecture_test.rb
+
+
+## Source
+
+An unsolved problem in mathematics named after mathematician Lothar Collatz [https://en.wikipedia.org/wiki/3x_%2B_1_problem](https://en.wikipedia.org/wiki/3x_%2B_1_problem)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/collatz-conjecture/collatz_conjecture_test.rb
+++ b/exercises/collatz-conjecture/collatz_conjecture_test.rb
@@ -1,0 +1,57 @@
+require 'minitest/autorun'
+require_relative 'collatz_conjecture'
+
+# Common test data version: 1.1.1 25c4479
+class CollatzConjectureTest < Minitest::Test
+  def test_zero_steps_for_one
+    # skip
+    assert_equal 0, CollatzConjecture.steps(1)
+  end
+
+  def test_divide_if_even
+    skip
+    assert_equal 4, CollatzConjecture.steps(16)
+  end
+
+  def test_even_and_odd_steps
+    skip
+    assert_equal 9, CollatzConjecture.steps(12)
+  end
+
+  def test_large_number_of_even_and_odd_steps
+    skip
+    assert_equal 152, CollatzConjecture.steps(1_000_000)
+  end
+
+  def test_zero_is_an_error
+    skip
+    assert_raises(ArgumentError) { CollatzConjecture.steps(0) }
+  end
+
+  def test_negative_value_is_an_error
+    skip
+    assert_raises(ArgumentError) { CollatzConjecture.steps(-15) }
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/complex-numbers/README.md
+++ b/exercises/complex-numbers/README.md
@@ -1,0 +1,62 @@
+# Complex Numbers
+
+A complex number is a number in the form `a + b * i` where `a` and `b` are real and `i` satisfies `i^2 = -1`.
+
+`a` is called the real part and `b` is called the imaginary part of `z`.
+The conjugate of the number `a + b * i` is the number `a - b * i`.
+The absolute value of a complex number `z = a + b * i` is a real number `|z| = sqrt(a^2 + b^2)`. The square of the absolute value `|z|^2` is the result of multiplication of `z` by its complex conjugate.
+
+The sum/difference of two complex numbers involves adding/subtracting their real and imaginary parts separately:
+`(a + i * b) + (c + i * d) = (a + c) + (b + d) * i`,
+`(a + i * b) - (c + i * d) = (a - c) + (b - d) * i`.
+
+Multiplication result is by definition
+`(a + i * b) * (c + i * d) = (a * c - b * d) + (b * c + a * d) * i`.
+
+The reciprocal of a non-zero complex number is
+`1 / (a + i * b) = a/(a^2 + b^2) - b/(a^2 + b^2) * i`.
+
+Dividing a complex number `a + i * b` by another `c + i * d` gives:
+`(a + i * b) / (c + i * d) = (a * c + b * d)/(c^2 + d^2) + (b * c - a * d)/(c^2 + d^2) * i`.
+
+Exponent of a complex number can be expressed as
+`exp(a + i * b) = exp(a) * exp(i * b)`,
+and the last term is given by Euler's formula `exp(i * b) = cos(b) + i * sin(b)`.
+
+
+Implement the following operations:
+ - addition, subtraction, multiplication and division of two complex numbers,
+ - conjugate, absolute value, exponent of a given complex number.
+
+
+Assume the programming language you are using does not have an implementation of complex numbers.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby complex_numbers_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride complex_numbers_test.rb
+
+
+## Source
+
+Wikipedia [https://en.wikipedia.org/wiki/Complex_number](https://en.wikipedia.org/wiki/Complex_number)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/complex-numbers/complex_numbers_test.rb
+++ b/exercises/complex-numbers/complex_numbers_test.rb
@@ -1,0 +1,207 @@
+require 'minitest/autorun'
+require_relative 'complex_numbers'
+
+# Common test data version: 1.0.0 '117d062'
+class ComplexNumberTest < Minitest::Test
+  def test_imaginary_unit
+    # skip
+    expected = ComplexNumber.new(-1, 0)
+    assert_equal expected, ComplexNumber.new(0, 1) * ComplexNumber.new(0, 1)
+  end
+
+  def test_add_purely_real_numbers
+    skip
+    expected = ComplexNumber.new(3, 0)
+    assert_equal expected, ComplexNumber.new(1, 0) + ComplexNumber.new(2, 0)
+  end
+
+  def test_add_purely_imaginary_numbers
+    skip
+    expected = ComplexNumber.new(0, 3)
+    assert_equal expected, ComplexNumber.new(0, 1) + ComplexNumber.new(0, 2)
+  end
+
+  def test_add_numbers_with_real_and_imaginary_part
+    skip
+    expected = ComplexNumber.new(4, 6)
+    assert_equal expected, ComplexNumber.new(1, 2) + ComplexNumber.new(3, 4)
+  end
+
+  def test_subtract_purely_real_numbers
+    skip
+    expected = ComplexNumber.new(-1, 0)
+    assert_equal expected, ComplexNumber.new(1, 0) - ComplexNumber.new(2, 0)
+  end
+
+  def test_subtract_purely_imaginary_numbers
+    skip
+    expected = ComplexNumber.new(0, -1)
+    assert_equal expected, ComplexNumber.new(0, 1) - ComplexNumber.new(0, 2)
+  end
+
+  def test_subtract_numbers_with_real_and_imaginary_part
+    skip
+    expected = ComplexNumber.new(-2, -2)
+    assert_equal expected, ComplexNumber.new(1, 2) - ComplexNumber.new(3, 4)
+  end
+
+  def test_multiply_purely_real_numbers
+    skip
+    expected = ComplexNumber.new(2, 0)
+    assert_equal expected, ComplexNumber.new(1, 0) * ComplexNumber.new(2, 0)
+  end
+
+  def test_multiply_purely_imaginary_numbers
+    skip
+    expected = ComplexNumber.new(-2, 0)
+    assert_equal expected, ComplexNumber.new(0, 1) * ComplexNumber.new(0, 2)
+  end
+
+  def test_multiply_numbers_with_real_and_imaginary_part
+    skip
+    expected = ComplexNumber.new(-5, 10)
+    assert_equal expected, ComplexNumber.new(1, 2) * ComplexNumber.new(3, 4)
+  end
+
+  def test_divide_purely_real_numbers
+    skip
+    expected = ComplexNumber.new(0.5, 0)
+    assert_equal expected, ComplexNumber.new(1, 0) / ComplexNumber.new(2, 0)
+  end
+
+  def test_divide_purely_imaginary_numbers
+    skip
+    expected = ComplexNumber.new(0.5, 0)
+    assert_equal expected, ComplexNumber.new(0, 1) / ComplexNumber.new(0, 2)
+  end
+
+  def test_divide_numbers_with_real_and_imaginary_part
+    skip
+    expected = ComplexNumber.new(0.44, 0.08)
+    assert_equal expected, ComplexNumber.new(1, 2) / ComplexNumber.new(3, 4)
+  end
+
+  def test_absolute_value_of_a_positive_purely_real_number
+    skip
+    expected = 5
+    assert_equal expected, ComplexNumber.new(5, 0).abs
+  end
+
+  def test_absolute_value_of_a_negative_purely_real_number
+    skip
+    expected = 5
+    assert_equal expected, ComplexNumber.new(-5, 0).abs
+  end
+
+  def test_absolute_value_of_a_purely_imaginary_number_with_positive_imaginary_part
+    skip
+    expected = 5
+    assert_equal expected, ComplexNumber.new(0, 5).abs
+  end
+
+  def test_absolute_value_of_a_purely_imaginary_number_with_negative_imaginary_part
+    skip
+    expected = 5
+    assert_equal expected, ComplexNumber.new(0, -5).abs
+  end
+
+  def test_absolute_value_of_a_number_with_real_and_imaginary_part
+    skip
+    expected = 5
+    assert_equal expected, ComplexNumber.new(3, 4).abs
+  end
+
+  def test_conjugate_a_purely_real_number
+    skip
+    expected = ComplexNumber.new(5, 0)
+    assert_equal expected, ComplexNumber.new(5, 0).conjugate
+  end
+
+  def test_conjugate_a_purely_imaginary_number
+    skip
+    expected = ComplexNumber.new(0, -5)
+    assert_equal expected, ComplexNumber.new(0, 5).conjugate
+  end
+
+  def test_conjugate_a_number_with_real_and_imaginary_part
+    skip
+    expected = ComplexNumber.new(1, -1)
+    assert_equal expected, ComplexNumber.new(1, 1).conjugate
+  end
+
+  def test_real_part_of_a_purely_real_number
+    skip
+    expected = 1
+    assert_equal expected, ComplexNumber.new(1, 0).real
+  end
+
+  def test_real_part_of_a_purely_imaginary_number
+    skip
+    expected = 0
+    assert_equal expected, ComplexNumber.new(0, 1).real
+  end
+
+  def test_real_part_of_a_number_with_real_and_imaginary_part
+    skip
+    expected = 1
+    assert_equal expected, ComplexNumber.new(1, 2).real
+  end
+
+  def test_imaginary_part_of_a_purely_real_number
+    skip
+    expected = 0
+    assert_equal expected, ComplexNumber.new(1, 0).imaginary
+  end
+
+  def test_imaginary_part_of_a_purely_imaginary_number
+    skip
+    expected = 1
+    assert_equal expected, ComplexNumber.new(0, 1).imaginary
+  end
+
+  def test_imaginary_part_of_a_number_with_real_and_imaginary_part
+    skip
+    expected = 2
+    assert_equal expected, ComplexNumber.new(1, 2).imaginary
+  end
+
+  def test_eulers_identityformula
+    skip
+    expected = ComplexNumber.new(-1, 0)
+    assert_equal expected, ComplexNumber.new(0, Math::PI).exp
+  end
+
+  def test_exponential_of_0
+    skip
+    expected = ComplexNumber.new(1, 0)
+    assert_equal expected, ComplexNumber.new(0, 0).exp
+  end
+
+  def test_exponential_of_a_purely_real_number
+    skip
+    expected = ComplexNumber.new(Math::E, 0)
+    assert_equal expected, ComplexNumber.new(1, 0).exp
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/connect/README.md
+++ b/exercises/connect/README.md
@@ -1,0 +1,57 @@
+# Connect
+
+Compute the result for a game of Hex / Polygon.
+
+The abstract boardgame known as
+[Hex](https://en.wikipedia.org/wiki/Hex_%28board_game%29) / Polygon /
+CON-TAC-TIX is quite simple in rules, though complex in practice. Two players
+place stones on a rhombus with hexagonal fields. The player to connect his/her
+stones to the opposite side first wins. The four sides of the rhombus are
+divided between the two players (i.e. one player gets assigned a side and the
+side directly opposite it and the other player gets assigned the two other
+sides).
+
+Your goal is to build a program that given a simple representation of a board
+computes the winner (or lack thereof). Note that all games need not be "fair".
+(For example, players may have mismatched piece counts.)
+
+The boards look like this (with spaces added for readability, which won't be in
+the representation passed to your code):
+
+```text
+. O . X .
+ . X X O .
+  O O O X .
+   . X O X O
+    X O O O X
+```
+
+"Player `O`" plays from top to bottom, "Player `X`" plays from left to right. In
+the above example `O` has made a connection from left to right but nobody has
+won since `O` didn't connect top and bottom.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby connect_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride connect_test.rb
+
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/connect/connect_test.rb
+++ b/exercises/connect/connect_test.rb
@@ -1,0 +1,151 @@
+require 'minitest/autorun'
+require_relative 'connect'
+
+# Common test data version: 1.0.0 327db7f
+class ConnectTest < Minitest::Test
+  def test_an_empty_board_has_no_winner
+    # skip
+    board = [
+      '. . . . .',
+      ' . . . . .',
+      '  . . . . .',
+      '   . . . . .',
+      '    . . . . .'
+    ]
+    game = Board.new(board)
+    assert_equal '', game.winner, 'an empty board has no winner'
+  end
+
+  def test_x_can_win_on_a_1x1_board
+    skip
+    board = [
+      'X'
+    ]
+    game = Board.new(board)
+    assert_equal 'X', game.winner, 'X can win on a 1x1 board'
+  end
+
+  def test_o_can_win_on_a_1x1_board
+    skip
+    board = [
+      'O'
+    ]
+    game = Board.new(board)
+    assert_equal 'O', game.winner, 'O can win on a 1x1 board'
+  end
+
+  def test_only_edges_does_not_make_a_winner
+    skip
+    board = [
+      'O O O X',
+      ' X . . X',
+      '  X . . X',
+      '   X O O O'
+    ]
+    game = Board.new(board)
+    assert_equal '', game.winner, 'only edges does not make a winner'
+  end
+
+  def test_illegal_diagonal_does_not_make_a_winner
+    skip
+    board = [
+      'X O . .',
+      ' O X X X',
+      '  O X O .',
+      '   . O X .',
+      '    X X O O'
+    ]
+    game = Board.new(board)
+    assert_equal '', game.winner, 'illegal diagonal does not make a winner'
+  end
+
+  def test_nobody_wins_crossing_adjacent_angles
+    skip
+    board = [
+      'X . . .',
+      ' . X O .',
+      '  O . X O',
+      '   . O . X',
+      '    . . O .'
+    ]
+    game = Board.new(board)
+    assert_equal '', game.winner, 'nobody wins crossing adjacent angles'
+  end
+
+  def test_x_wins_crossing_from_left_to_right
+    skip
+    board = [
+      '. O . .',
+      ' O X X X',
+      '  O X O .',
+      '   X X O X',
+      '    . O X .'
+    ]
+    game = Board.new(board)
+    assert_equal 'X', game.winner, 'X wins crossing from left to right'
+  end
+
+  def test_o_wins_crossing_from_top_to_bottom
+    skip
+    board = [
+      '. O . .',
+      ' O X X X',
+      '  O O O .',
+      '   X X O X',
+      '    . O X .'
+    ]
+    game = Board.new(board)
+    assert_equal 'O', game.winner, 'O wins crossing from top to bottom'
+  end
+
+  def test_x_wins_using_a_convoluted_path
+    skip
+    board = [
+      '. X X . .',
+      ' X . X . X',
+      '  . X . X .',
+      '   . X X . .',
+      '    O O O O O'
+    ]
+    game = Board.new(board)
+    assert_equal 'X', game.winner, 'X wins using a convoluted path'
+  end
+
+  def test_x_wins_using_a_spiral_path
+    skip
+    board = [
+      'O X X X X X X X X',
+      ' O X O O O O O O O',
+      '  O X O X X X X X O',
+      '   O X O X O O O X O',
+      '    O X O X X X O X O',
+      '     O X O O O X O X O',
+      '      O X X X X X O X O',
+      '       O O O O O O O X O',
+      '        X X X X X X X X O'
+    ]
+    game = Board.new(board)
+    assert_equal 'X', game.winner, 'X wins using a spiral path'
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+  def test_bookkeeping
+    skip
+    assert_equal 2, BookKeeping::VERSION
+  end
+end

--- a/exercises/crypto-square/README.md
+++ b/exercises/crypto-square/README.md
@@ -1,0 +1,100 @@
+# Crypto Square
+
+Implement the classic method for composing secret messages called a square code.
+
+Given an English text, output the encoded version of that text.
+
+First, the input is normalized: the spaces and punctuation are removed
+from the English text and the message is downcased.
+
+Then, the normalized characters are broken into rows.  These rows can be
+regarded as forming a rectangle when printed with intervening newlines.
+
+For example, the sentence
+
+> If man was meant to stay on the ground, god would have given us roots.
+
+is normalized to:
+
+> ifmanwasmeanttostayonthegroundgodwouldhavegivenusroots
+
+The plaintext should be organized in to a rectangle.  The size of the
+rectangle (`r x c`) should be decided by the length of the message,
+such that `c >= r` and `c - r <= 1`, where `c` is the number of columns
+and `r` is the number of rows.
+
+Our normalized text is 54 characters long, dictating a rectangle with
+`c = 8` and `r = 7`:
+
+```text
+ifmanwas
+meanttos
+tayonthe
+groundgo
+dwouldha
+vegivenu
+sroots
+```
+
+The coded message is obtained by reading down the columns going left to
+right.
+
+The message above is coded as:
+
+```text
+imtgdvsfearwermayoogoanouuiontnnlvtwttddesaohghnsseoau
+```
+
+Output the encoded text in chunks.  Phrases that fill perfect rectangles
+`(r X c)` should be output `c` chunks of `r` length, separated by spaces.
+Phrases that do not fill perfect rectangles will have `n` empty spaces.
+Those spaces should be distributed evenly, added to the end of the last
+`n` chunks.
+
+```text
+imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau 
+```
+
+Notice that were we to stack these, we could visually decode the
+cyphertext back in to the original message:
+
+```text
+imtgdvs
+fearwer
+mayoogo
+anouuio
+ntnnlvt
+wttddes
+aohghn
+sseoau
+```
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby crypto_square_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride crypto_square_test.rb
+
+
+## Source
+
+J Dalbey's Programming Practice problems [http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html](http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/crypto-square/crypto_square_test.rb
+++ b/exercises/crypto-square/crypto_square_test.rb
@@ -1,0 +1,69 @@
+require 'minitest/autorun'
+require_relative 'crypto_square'
+
+# Common test data version: 3.1.0 e937744
+class CryptoSquareTest < Minitest::Test
+  def test_empty_plaintext_results_in_an_empty_ciphertext
+    # skip
+    plaintext = ''
+    assert_equal "", Crypto.new(plaintext).ciphertext
+  end
+
+  def test_lowercase
+    skip
+    plaintext = 'A'
+    assert_equal "a", Crypto.new(plaintext).ciphertext
+  end
+
+  def test_remove_spaces
+    skip
+    plaintext = '  b '
+    assert_equal "b", Crypto.new(plaintext).ciphertext
+  end
+
+  def test_remove_punctuation
+    skip
+    plaintext = '@1,%!'
+    assert_equal "1", Crypto.new(plaintext).ciphertext
+  end
+
+  def test_9_character_plaintext_results_in_3_chunks_of_3_characters
+    skip
+    plaintext = 'This is fun!'
+    assert_equal "tsf hiu isn", Crypto.new(plaintext).ciphertext
+  end
+
+  def test_8_character_plaintext_results_in_3_chunks_the_last_one_with_a_trailing_space
+    skip
+    plaintext = 'Chill out.'
+    assert_equal "clu hlt io ", Crypto.new(plaintext).ciphertext
+  end
+
+  def test_54_character_plaintext_results_in_7_chunks_the_last_two_with_trailing_spaces
+    skip
+    plaintext = 'If man was meant to stay on the ground, god would have given us roots.'
+    assert_equal "imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau ", Crypto.new(plaintext).ciphertext
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/custom-set/README.md
+++ b/exercises/custom-set/README.md
@@ -1,0 +1,34 @@
+# Custom Set
+
+Create a custom set type.
+
+Sometimes it is necessary to define a custom data structure of some
+type, like a set. In this exercise you will define your own set. How it
+works internally doesn't matter, as long as it behaves like a set of
+unique elements.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby custom_set_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride custom_set_test.rb
+
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/custom-set/custom_set_test.rb
+++ b/exercises/custom-set/custom_set_test.rb
@@ -1,0 +1,297 @@
+require 'minitest/autorun'
+require_relative 'custom_set'
+
+# Common test data version: 1.0.1 4527635
+class CustomSetTest < Minitest::Test
+  def test_sets_with_no_elements_are_empty
+    # skip
+    set = CustomSet.new []
+    assert_empty set
+  end
+
+  def test_sets_with_elements_are_not_empty
+    skip
+    set = CustomSet.new [1]
+    refute_empty set
+  end
+
+  def test_nothing_is_contained_in_an_empty_set
+    skip
+    set = CustomSet.new []
+    element = 1
+    refute set.member? element
+  end
+
+  def test_when_the_element_is_in_the_set
+    skip
+    set = CustomSet.new [1, 2, 3]
+    element = 1
+    assert set.member? element
+  end
+
+  def test_when_the_element_is_not_in_the_set
+    skip
+    set = CustomSet.new [1, 2, 3]
+    element = 4
+    refute set.member? element
+  end
+
+  def test_empty_set_is_a_subset_of_another_empty_set
+    skip
+    set1 = CustomSet.new []
+    set2 = CustomSet.new []
+    assert set1.subset? set2
+  end
+
+  def test_empty_set_is_a_subset_of_non_empty_set
+    skip
+    set1 = CustomSet.new []
+    set2 = CustomSet.new [1]
+    assert set1.subset? set2
+  end
+
+  def test_non_empty_set_is_not_a_subset_of_empty_set
+    skip
+    set1 = CustomSet.new [1]
+    set2 = CustomSet.new []
+    refute set1.subset? set2
+  end
+
+  def test_set_is_a_subset_of_set_with_exact_same_elements
+    skip
+    set1 = CustomSet.new [1, 2, 3]
+    set2 = CustomSet.new [1, 2, 3]
+    assert set1.subset? set2
+  end
+
+  def test_set_is_a_subset_of_larger_set_with_same_elements
+    skip
+    set1 = CustomSet.new [1, 2, 3]
+    set2 = CustomSet.new [4, 1, 2, 3]
+    assert set1.subset? set2
+  end
+
+  def test_set_is_not_a_subset_of_set_that_does_not_contain_its_elements
+    skip
+    set1 = CustomSet.new [1, 2, 3]
+    set2 = CustomSet.new [4, 1, 3]
+    refute set1.subset? set2
+  end
+
+  def test_the_empty_set_is_disjoint_with_itself
+    skip
+    set1 = CustomSet.new []
+    set2 = CustomSet.new []
+    assert set1.disjoint? set2
+  end
+
+  def test_empty_set_is_disjoint_with_non_empty_set
+    skip
+    set1 = CustomSet.new []
+    set2 = CustomSet.new [1]
+    assert set1.disjoint? set2
+  end
+
+  def test_non_empty_set_is_disjoint_with_empty_set
+    skip
+    set1 = CustomSet.new [1]
+    set2 = CustomSet.new []
+    assert set1.disjoint? set2
+  end
+
+  def test_sets_are_not_disjoint_if_they_share_an_element
+    skip
+    set1 = CustomSet.new [1, 2]
+    set2 = CustomSet.new [2, 3]
+    refute set1.disjoint? set2
+  end
+
+  def test_sets_are_disjoint_if_they_share_no_elements
+    skip
+    set1 = CustomSet.new [1, 2]
+    set2 = CustomSet.new [3, 4]
+    assert set1.disjoint? set2
+  end
+
+  def test_empty_sets_are_equal
+    skip
+    set1 = CustomSet.new []
+    set2 = CustomSet.new []
+    assert_equal set1, set2
+  end
+
+  def test_empty_set_is_not_equal_to_non_empty_set
+    skip
+    set1 = CustomSet.new []
+    set2 = CustomSet.new [1, 2, 3]
+    refute_equal set1, set2
+  end
+
+  def test_non_empty_set_is_not_equal_to_empty_set
+    skip
+    set1 = CustomSet.new [1, 2, 3]
+    set2 = CustomSet.new []
+    refute_equal set1, set2
+  end
+
+  def test_sets_with_the_same_elements_are_equal
+    skip
+    set1 = CustomSet.new [1, 2]
+    set2 = CustomSet.new [2, 1]
+    assert_equal set1, set2
+  end
+
+  def test_sets_with_different_elements_are_not_equal
+    skip
+    set1 = CustomSet.new [1, 2, 3]
+    set2 = CustomSet.new [1, 2, 4]
+    refute_equal set1, set2
+  end
+
+  def test_add_to_empty_set
+    skip
+    set = CustomSet.new []
+    expected = CustomSet.new [3]
+    assert_equal expected, set.add(3)
+  end
+
+  def test_add_to_non_empty_set
+    skip
+    set = CustomSet.new [1, 2, 4]
+    expected = CustomSet.new [1, 2, 3, 4]
+    assert_equal expected, set.add(3)
+  end
+
+  def test_adding_an_existing_element_does_not_change_the_set
+    skip
+    set = CustomSet.new [1, 2, 3]
+    expected = CustomSet.new [1, 2, 3]
+    assert_equal expected, set.add(3)
+  end
+
+  def test_intersection_of_two_empty_sets_is_an_empty_set
+    skip
+    set1 = CustomSet.new []
+    set2 = CustomSet.new []
+    expected = CustomSet.new []
+    assert_equal expected, set2.intersection(set1)
+  end
+
+  def test_intersection_of_an_empty_set_and_non_empty_set_is_an_empty_set
+    skip
+    set1 = CustomSet.new []
+    set2 = CustomSet.new [3, 2, 5]
+    expected = CustomSet.new []
+    assert_equal expected, set2.intersection(set1)
+  end
+
+  def test_intersection_of_a_non_empty_set_and_an_empty_set_is_an_empty_set
+    skip
+    set1 = CustomSet.new [1, 2, 3, 4]
+    set2 = CustomSet.new []
+    expected = CustomSet.new []
+    assert_equal expected, set2.intersection(set1)
+  end
+
+  def test_intersection_of_two_sets_with_no_shared_elements_is_an_empty_set
+    skip
+    set1 = CustomSet.new [1, 2, 3]
+    set2 = CustomSet.new [4, 5, 6]
+    expected = CustomSet.new []
+    assert_equal expected, set2.intersection(set1)
+  end
+
+  def test_intersection_of_two_sets_with_shared_elements_is_a_set_of_the_shared_elements
+    skip
+    set1 = CustomSet.new [1, 2, 3, 4]
+    set2 = CustomSet.new [3, 2, 5]
+    expected = CustomSet.new [2, 3]
+    assert_equal expected, set2.intersection(set1)
+  end
+
+  def test_difference_of_two_empty_sets_is_an_empty_set
+    skip
+    set1 = CustomSet.new []
+    set2 = CustomSet.new []
+    expected = CustomSet.new []
+    assert_equal expected, set1.difference(set2)
+  end
+
+  def test_difference_of_empty_set_and_non_empty_set_is_an_empty_set
+    skip
+    set1 = CustomSet.new []
+    set2 = CustomSet.new [3, 2, 5]
+    expected = CustomSet.new []
+    assert_equal expected, set1.difference(set2)
+  end
+
+  def test_difference_of_a_non_empty_set_and_an_empty_set_is_the_non_empty_set
+    skip
+    set1 = CustomSet.new [1, 2, 3, 4]
+    set2 = CustomSet.new []
+    expected = CustomSet.new [1, 2, 3, 4]
+    assert_equal expected, set1.difference(set2)
+  end
+
+  def test_difference_of_two_non_empty_sets_is_a_set_of_elements_that_are_only_in_the_first_set
+    skip
+    set1 = CustomSet.new [3, 2, 1]
+    set2 = CustomSet.new [2, 4]
+    expected = CustomSet.new [1, 3]
+    assert_equal expected, set1.difference(set2)
+  end
+
+  def test_union_of_empty_sets_is_an_empty_set
+    skip
+    set1 = CustomSet.new []
+    set2 = CustomSet.new []
+    expected = CustomSet.new []
+    assert_equal expected, set1.union(set2)
+  end
+
+  def test_union_of_an_empty_set_and_non_empty_set_is_the_non_empty_set
+    skip
+    set1 = CustomSet.new []
+    set2 = CustomSet.new [2]
+    expected = CustomSet.new [2]
+    assert_equal expected, set1.union(set2)
+  end
+
+  def test_union_of_a_non_empty_set_and_empty_set_is_the_non_empty_set
+    skip
+    set1 = CustomSet.new [1, 3]
+    set2 = CustomSet.new []
+    expected = CustomSet.new [1, 3]
+    assert_equal expected, set1.union(set2)
+  end
+
+  def test_union_of_non_empty_sets_contains_all_unique_elements
+    skip
+    set1 = CustomSet.new [1, 3]
+    set2 = CustomSet.new [2, 3]
+    expected = CustomSet.new [3, 2, 1]
+    assert_equal expected, set1.union(set2)
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/diamond/README.md
+++ b/exercises/diamond/README.md
@@ -1,0 +1,83 @@
+# Diamond
+
+The diamond kata takes as its input a letter, and outputs it in a diamond
+shape. Given a letter, it prints a diamond starting with 'A', with the
+supplied letter at the widest point.
+
+## Requirements
+
+* The first row contains one 'A'.
+* The last row contains one 'A'.
+* All rows, except the first and last, have exactly two identical letters.
+* All rows have as many trailing spaces as leading spaces. (This might be 0).
+* The diamond is horizontally symmetric.
+* The diamond is vertically symmetric.
+* The diamond has a square shape (width equals height).
+* The letters form a diamond shape.
+* The top half has the letters in ascending order.
+* The bottom half has the letters in descending order.
+* The four corners (containing the spaces) are triangles.
+
+## Examples
+
+In the following examples, spaces are indicated by `·` characters.
+
+Diamond for letter 'A':
+
+```text
+A
+```
+
+Diamond for letter 'C':
+
+```text
+··A··
+·B·B·
+C···C
+·B·B·
+··A··
+```
+
+Diamond for letter 'E':
+
+```text
+····A····
+···B·B···
+··C···C··
+·D·····D·
+E·······E
+·D·····D·
+··C···C··
+···B·B···
+····A····
+```
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby diamond_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride diamond_test.rb
+
+
+## Source
+
+Seb Rose [http://claysnow.co.uk/recycling-tests-in-tdd/](http://claysnow.co.uk/recycling-tests-in-tdd/)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/diamond/diamond_test.rb
+++ b/exercises/diamond/diamond_test.rb
@@ -1,0 +1,40 @@
+require 'minitest/autorun'
+require_relative 'diamond'
+
+class DiamondTest < Minitest::Test
+  def test_letter_a
+    answer = Diamond.make_diamond('A')
+    assert_equal "A\n", answer
+  end
+
+  def test_letter_c
+    skip
+    answer = Diamond.make_diamond('C')
+    string = "  A  \n"\
+             " B B \n"\
+             "C   C\n"\
+             " B B \n"\
+             "  A  \n"
+    assert_equal string, answer
+  end
+
+  def test_letter_e
+    skip
+    answer = Diamond.make_diamond('E')
+    string = "    A    \n"\
+             "   B B   \n"\
+             "  C   C  \n"\
+             " D     D \n"\
+             "E       E\n"\
+             " D     D \n"\
+             "  C   C  \n"\
+             "   B B   \n"\
+             "    A    \n"
+    assert_equal string, answer
+  end
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, Bookkeeping::VERSION
+  end
+end

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -1,0 +1,43 @@
+# Difference Of Squares
+
+Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.
+
+The square of the sum of the first ten natural numbers is
+(1 + 2 + ... + 10)² = 55² = 3025.
+
+The sum of the squares of the first ten natural numbers is
+1² + 2² + ... + 10² = 385.
+
+Hence the difference between the square of the sum of the first
+ten natural numbers and the sum of the squares of the first ten
+natural numbers is 3025 - 385 = 2640.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby difference_of_squares_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride difference_of_squares_test.rb
+
+
+## Source
+
+Problem 6 at Project Euler [http://projecteuler.net/problem=6](http://projecteuler.net/problem=6)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/difference-of-squares/difference_of_squares_test.rb
+++ b/exercises/difference-of-squares/difference_of_squares_test.rb
@@ -1,0 +1,72 @@
+require 'minitest/autorun'
+require_relative 'difference_of_squares'
+
+# Common test data version: 1.1.0 7a1108b
+class DifferenceOfSquaresTest < Minitest::Test
+  def test_square_of_sum_1
+    # skip
+    assert_equal 1, Squares.new(1).square_of_sum
+  end
+
+  def test_square_of_sum_5
+    skip
+    assert_equal 225, Squares.new(5).square_of_sum
+  end
+
+  def test_square_of_sum_100
+    skip
+    assert_equal 25_502_500, Squares.new(100).square_of_sum
+  end
+
+  def test_sum_of_squares_1
+    skip
+    assert_equal 1, Squares.new(1).sum_of_squares
+  end
+
+  def test_sum_of_squares_5
+    skip
+    assert_equal 55, Squares.new(5).sum_of_squares
+  end
+
+  def test_sum_of_squares_100
+    skip
+    assert_equal 338_350, Squares.new(100).sum_of_squares
+  end
+
+  def test_difference_of_squares_1
+    skip
+    assert_equal 0, Squares.new(1).difference
+  end
+
+  def test_difference_of_squares_5
+    skip
+    assert_equal 170, Squares.new(5).difference
+  end
+
+  def test_difference_of_squares_100
+    skip
+    assert_equal 25_164_150, Squares.new(100).difference
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 4, BookKeeping::VERSION
+  end
+end

--- a/exercises/dominoes/README.md
+++ b/exercises/dominoes/README.md
@@ -1,0 +1,41 @@
+# Dominoes
+
+Make a chain of dominoes.
+
+Compute a way to order a given set of dominoes in such a way that they form a
+correct domino chain (the dots on one half of a stone match the dots on the
+neighbouring half of an adjacent stone) and that dots on the halfs of the stones
+which don't have a neighbour (the first and last stone) match each other.
+
+For example given the stones `[2|1]`, `[2|3]` and `[1|3]` you should compute something
+like `[1|2] [2|3] [3|1]` or `[3|2] [2|1] [1|3]` or `[1|3] [3|2] [2|1]` etc, where the first and last numbers are the same.
+
+For stones `[1|2]`, `[4|1]` and `[2|3]` the resulting chain is not valid: `[4|1] [1|2] [2|3]`'s first and last numbers are not the same. 4 != 3
+
+Some test cases may use duplicate stones in a chain solution, assume that multiple Domino sets are being used.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby dominoes_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride dominoes_test.rb
+
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/dominoes/dominoes_test.rb
+++ b/exercises/dominoes/dominoes_test.rb
@@ -1,0 +1,147 @@
+require 'minitest/autorun'
+require_relative 'dominoes'
+
+# Common test data version: 2.0.0 b4ceaf4
+class DominoesTest < Minitest::Test
+  def test_empty_input_empty_output
+    # skip
+    input_dominoes = []
+    output_chain = Dominoes.chain(input_dominoes)
+    assert_correct_chain(input_dominoes, output_chain)
+  end
+
+  def test_singleton_input_singleton_output
+    skip
+    input_dominoes = [[1, 1]]
+    output_chain = Dominoes.chain(input_dominoes)
+    assert_correct_chain(input_dominoes, output_chain)
+  end
+
+  def test_singleton_that_can_not_be_chained
+    skip
+    input_dominoes = [[1, 2]]
+    output_chain = Dominoes.chain(input_dominoes)
+    refute_correct_chain(input_dominoes, output_chain)
+  end
+
+  def test_three_elements
+    skip
+    input_dominoes = [[1, 2], [3, 1], [2, 3]]
+    output_chain = Dominoes.chain(input_dominoes)
+    assert_correct_chain(input_dominoes, output_chain)
+  end
+
+  def test_can_reverse_dominoes
+    skip
+    input_dominoes = [[1, 2], [1, 3], [2, 3]]
+    output_chain = Dominoes.chain(input_dominoes)
+    assert_correct_chain(input_dominoes, output_chain)
+  end
+
+  def test_can_not_be_chained
+    skip
+    input_dominoes = [[1, 2], [4, 1], [2, 3]]
+    output_chain = Dominoes.chain(input_dominoes)
+    refute_correct_chain(input_dominoes, output_chain)
+  end
+
+  def test_disconnected_simple
+    skip
+    input_dominoes = [[1, 1], [2, 2]]
+    output_chain = Dominoes.chain(input_dominoes)
+    refute_correct_chain(input_dominoes, output_chain)
+  end
+
+  def test_disconnected_double_loop
+    skip
+    input_dominoes = [[1, 2], [2, 1], [3, 4], [4, 3]]
+    output_chain = Dominoes.chain(input_dominoes)
+    refute_correct_chain(input_dominoes, output_chain)
+  end
+
+  def test_disconnected_single_isolated
+    skip
+    input_dominoes = [[1, 2], [2, 3], [3, 1], [4, 4]]
+    output_chain = Dominoes.chain(input_dominoes)
+    refute_correct_chain(input_dominoes, output_chain)
+  end
+
+  def test_need_backtrack
+    skip
+    input_dominoes = [[1, 2], [2, 3], [3, 1], [2, 4], [2, 4]]
+    output_chain = Dominoes.chain(input_dominoes)
+    assert_correct_chain(input_dominoes, output_chain)
+  end
+
+  def test_separate_loops
+    skip
+    input_dominoes = [[1, 2], [2, 3], [3, 1], [1, 1], [2, 2], [3, 3]]
+    output_chain = Dominoes.chain(input_dominoes)
+    assert_correct_chain(input_dominoes, output_chain)
+  end
+
+  def test_nine_elements
+    skip
+    input_dominoes = [[1, 2], [5, 3], [3, 1], [1, 2], [2, 4], [1, 6], [2, 3], [3, 4], [5, 6]]
+    output_chain = Dominoes.chain(input_dominoes)
+    assert_correct_chain(input_dominoes, output_chain)
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+
+  # It's infeasible to use example-based tests for this exercise,
+  # because the list of acceptable answers for a given input can be quite large.
+  # Instead, we verify certain properties of a correct chain.
+
+  def assert_correct_chain(input_dominoes, output_chain)
+    refute_nil output_chain, "There should be a chain for #{input_dominoes}"
+    assert_same_dominoes(input_dominoes, output_chain)
+    return if output_chain.empty?
+    assert_consecutive_dominoes_match(output_chain)
+    assert_dominoes_at_end_match(output_chain)
+  end
+
+  def assert_same_dominoes(input_dominoes, output_chain)
+    input_normal = input_dominoes.map(&:sort).sort
+    output_normal = output_chain.map(&:sort).sort
+    assert_equal input_normal, output_normal,
+      'Dominoes used in the output must be the same as the ones given in the input'
+  end
+
+  def assert_consecutive_dominoes_match(chain)
+    chain.each_cons(2).with_index { |(d1, d2), i|
+      assert_equal d1.last, d2.first,
+        "In chain #{chain}, right end of domino #{i} (#{d1}) and left end of domino #{i + 1} (#{d2}) must match"
+    }
+  end
+
+  def assert_dominoes_at_end_match(chain)
+    first_domino = chain.first
+    last_domino = chain.last
+    assert_equal first_domino.first, last_domino.last,
+      "In chain #{chain}, left end of first domino (#{first_domino}) and right end of last domino (#{last_domino}) must match"
+  end
+
+  def refute_correct_chain(input_dominoes, output_chain)
+    assert_nil output_chain, "There should be no chain for #{input_dominoes}"
+  end
+end

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -1,0 +1,77 @@
+# ETL
+
+We are going to do the `Transform` step of an Extract-Transform-Load.
+
+### ETL
+
+Extract-Transform-Load (ETL) is a fancy way of saying, "We have some crufty, legacy data over in this system, and now we need it in this shiny new system over here, so
+we're going to migrate this."
+
+(Typically, this is followed by, "We're only going to need to run this
+once." That's then typically followed by much forehead slapping and
+moaning about how stupid we could possibly be.)
+
+### The goal
+
+We're going to extract some scrabble scores from a legacy system.
+
+The old system stored a list of letters per score:
+
+- 1 point: "A", "E", "I", "O", "U", "L", "N", "R", "S", "T",
+- 2 points: "D", "G",
+- 3 points: "B", "C", "M", "P",
+- 4 points: "F", "H", "V", "W", "Y",
+- 5 points: "K",
+- 8 points: "J", "X",
+- 10 points: "Q", "Z",
+
+The shiny new scrabble system instead stores the score per letter, which
+makes it much faster and easier to calculate the score for a word. It
+also stores the letters in lower-case regardless of the case of the
+input letters:
+
+- "a" is worth 1 point.
+- "b" is worth 3 points.
+- "c" is worth 3 points.
+- "d" is worth 2 points.
+- Etc.
+
+Your mission, should you choose to accept it, is to transform the legacy data
+format to the shiny new format.
+
+### Notes
+
+A final note about scoring, Scrabble is played around the world in a
+variety of languages, each with its own unique scoring table. For
+example, an "E" is scored at 2 in the Māori-language version of the
+game while being scored at 4 in the Hawaiian-language version.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby etl_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride etl_test.rb
+
+
+## Source
+
+The Jumpstart Lab team [http://jumpstartlab.com](http://jumpstartlab.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/etl/etl_test.rb
+++ b/exercises/etl/etl_test.rb
@@ -1,0 +1,110 @@
+require 'minitest/autorun'
+require_relative 'etl'
+
+# Common test data version: 1.0.0 ca9ed58
+class EtlTest < Minitest::Test
+  def test_a_single_letter
+    # skip
+    old = {
+      1 => ["A"]
+    }
+    expected = {
+      'a' => 1
+    }
+    assert_equal expected, ETL.transform(old)
+  end
+
+  def test_single_score_with_multiple_letters
+    skip
+    old = {
+      1 => ["A", "E", "I", "O", "U"]
+    }
+    expected = {
+      'a' => 1,
+      'e' => 1,
+      'i' => 1,
+      'o' => 1,
+      'u' => 1
+    }
+    assert_equal expected, ETL.transform(old)
+  end
+
+  def test_multiple_scores_with_multiple_letters
+    skip
+    old = {
+      1 => ["A", "E"],
+      2 => ["D", "G"]
+    }
+    expected = {
+      'a' => 1,
+      'd' => 2,
+      'e' => 1,
+      'g' => 2
+    }
+    assert_equal expected, ETL.transform(old)
+  end
+
+  def test_multiple_scores_with_differing_numbers_of_letters
+    skip
+    old = {
+      1 => ["A", "E", "I", "O", "U", "L", "N", "R", "S", "T"],
+      2 => ["D", "G"],
+      3 => ["B", "C", "M", "P"],
+      4 => ["F", "H", "V", "W", "Y"],
+      5 => ["K"],
+      8 => ["J", "X"],
+      10 => ["Q", "Z"]
+    }
+    expected = {
+      'a' => 1,
+      'b' => 3,
+      'c' => 3,
+      'd' => 2,
+      'e' => 1,
+      'f' => 4,
+      'g' => 2,
+      'h' => 4,
+      'i' => 1,
+      'j' => 8,
+      'k' => 5,
+      'l' => 1,
+      'm' => 3,
+      'n' => 1,
+      'o' => 1,
+      'p' => 3,
+      'q' => 10,
+      'r' => 1,
+      's' => 1,
+      't' => 1,
+      'u' => 1,
+      'v' => 4,
+      'w' => 4,
+      'x' => 8,
+      'y' => 4,
+      'z' => 10
+    }
+    assert_equal expected, ETL.transform(old)
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/flatten-array/README.md
+++ b/exercises/flatten-array/README.md
@@ -1,0 +1,41 @@
+# Flatten Array
+
+Take a nested list and return a single flattened list with all values except nil/null.
+
+The challenge is to write a function that accepts an arbitrarily-deep nested list-like structure and returns a flattened structure without any nil/null values.
+
+For Example
+
+input: [1,[2,3,null,4],[null],5]
+
+output: [1,2,3,4,5]
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby flatten_array_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride flatten_array_test.rb
+
+
+## Source
+
+Interview Question [https://reference.wolfram.com/language/ref/Flatten.html](https://reference.wolfram.com/language/ref/Flatten.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/flatten-array/flatten_array_test.rb
+++ b/exercises/flatten-array/flatten_array_test.rb
@@ -1,0 +1,63 @@
+require 'minitest/autorun'
+require_relative 'flatten_array'
+
+# Common test data version: 1.1.0 d7a3c09
+class FlattenArrayTest < Minitest::Test
+  def test_no_nesting
+    # skip
+    fa = FlattenArray.flatten([0, 1, 2])
+    assert_equal [0, 1, 2], fa
+  end
+
+  def test_flattens_array_with_just_integers_present
+    skip
+    fa = FlattenArray.flatten([1, [2, 3, 4, 5, 6, 7], 8])
+    assert_equal [1, 2, 3, 4, 5, 6, 7, 8], fa
+  end
+
+  def test_5_level_nesting
+    skip
+    fa = FlattenArray.flatten([0, 2, [[2, 3], 8, 100, 4, [[[50]]]], -2])
+    assert_equal [0, 2, 2, 3, 8, 100, 4, 50, -2], fa
+  end
+
+  def test_6_level_nesting
+    skip
+    fa = FlattenArray.flatten([1, [2, [[3]], [4, [[5]]], 6, 7], 8])
+    assert_equal [1, 2, 3, 4, 5, 6, 7, 8], fa
+  end
+
+  def test_6_level_nest_list_with_null_values
+    skip
+    fa = FlattenArray.flatten([0, 2, [[2, 3], 8, [[100]], nil, [[nil]]], -2])
+    assert_equal [0, 2, 2, 3, 8, 100, -2], fa
+  end
+
+  def test_all_values_in_nested_list_are_null
+    skip
+    fa = FlattenArray.flatten([nil, [[[nil]]], nil, nil, [[nil, nil], nil], nil])
+    assert_equal [], fa
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/food-chain/README.md
+++ b/exercises/food-chain/README.md
@@ -1,0 +1,94 @@
+# Food Chain
+
+Generate the lyrics of the song 'I Know an Old Lady Who Swallowed a Fly'.
+
+While you could copy/paste the lyrics,
+or read them from a file, this problem is much more
+interesting if you approach it algorithmically.
+
+This is a [cumulative song](http://en.wikipedia.org/wiki/Cumulative_song) of unknown origin.
+
+This is one of many common variants.
+
+```text
+I know an old lady who swallowed a fly.
+I don't know why she swallowed the fly. Perhaps she'll die.
+
+I know an old lady who swallowed a spider.
+It wriggled and jiggled and tickled inside her.
+She swallowed the spider to catch the fly.
+I don't know why she swallowed the fly. Perhaps she'll die.
+
+I know an old lady who swallowed a bird.
+How absurd to swallow a bird!
+She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.
+She swallowed the spider to catch the fly.
+I don't know why she swallowed the fly. Perhaps she'll die.
+
+I know an old lady who swallowed a cat.
+Imagine that, to swallow a cat!
+She swallowed the cat to catch the bird.
+She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.
+She swallowed the spider to catch the fly.
+I don't know why she swallowed the fly. Perhaps she'll die.
+
+I know an old lady who swallowed a dog.
+What a hog, to swallow a dog!
+She swallowed the dog to catch the cat.
+She swallowed the cat to catch the bird.
+She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.
+She swallowed the spider to catch the fly.
+I don't know why she swallowed the fly. Perhaps she'll die.
+
+I know an old lady who swallowed a goat.
+Just opened her throat and swallowed a goat!
+She swallowed the goat to catch the dog.
+She swallowed the dog to catch the cat.
+She swallowed the cat to catch the bird.
+She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.
+She swallowed the spider to catch the fly.
+I don't know why she swallowed the fly. Perhaps she'll die.
+
+I know an old lady who swallowed a cow.
+I don't know how she swallowed a cow!
+She swallowed the cow to catch the goat.
+She swallowed the goat to catch the dog.
+She swallowed the dog to catch the cat.
+She swallowed the cat to catch the bird.
+She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.
+She swallowed the spider to catch the fly.
+I don't know why she swallowed the fly. Perhaps she'll die.
+
+I know an old lady who swallowed a horse.
+She's dead, of course!
+```
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby food_chain_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride food_chain_test.rb
+
+
+## Source
+
+Wikipedia [http://en.wikipedia.org/wiki/There_Was_an_Old_Lady_Who_Swallowed_a_Fly](http://en.wikipedia.org/wiki/There_Was_an_Old_Lady_Who_Swallowed_a_Fly)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/food-chain/food_chain_test.rb
+++ b/exercises/food-chain/food_chain_test.rb
@@ -1,0 +1,82 @@
+require 'minitest/autorun'
+
+require_relative 'food_chain'
+
+class NoCheating < IOError
+  def message
+    "The use of File.open and IO.read is restricted.\n"                \
+    'This exercise intends to help you improve your ability to work ' \
+    'with data generated from your code. Your program must not read ' \
+    'the song.txt file.'
+  end
+end
+
+class FoodChainTest < Minitest::Test
+  # This test is an acceptance test.
+  #
+  # If you find it difficult to work the problem with so much
+  # output, go ahead and add a `skip`, and write whatever
+  # unit tests will help you. Then unskip it again
+  # to make sure you got it right.
+  # There's no need to submit the tests you write, unless you
+  # specifically want feedback on them.
+  def test_the_whole_song
+    song_file = File.expand_path('../song.txt', __FILE__)
+    expected  = IO.read(song_file)
+    assert_equal expected, FoodChain.song
+  end
+
+  # Tests that an error is effectively raised when IO.read or
+  # File.open are used within FoodChain.
+  def test_read_guard
+    song_file = File.expand_path('../song.txt', __FILE__)
+    ["IO.read '#{song_file}'", "File.open '#{song_file}'"].each do |trigger|
+      assert_raises(NoCheating) { FoodChain.send :class_eval, trigger }
+    end
+  end
+
+  # Problems in exercism evolve over time,
+  # as we find better ways to ask questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of BookKeeping.
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+  def test_version
+    skip
+    assert_equal 2, BookKeeping::VERSION
+  end
+end
+
+module RestrictedClasses
+  class File
+    def self.open(*)
+      fail NoCheating
+    end
+
+    def self.read(*)
+      fail NoCheating
+    end
+
+    def open(*)
+      fail NoCheating
+    end
+
+    def read(*)
+      fail NoCheating
+    end
+  end
+
+  class IO
+    def self.read(*)
+      fail NoCheating
+    end
+
+    def read(*)
+      fail NoCheating
+    end
+  end
+end
+
+FoodChain.prepend RestrictedClasses

--- a/exercises/food-chain/song.txt
+++ b/exercises/food-chain/song.txt
@@ -1,0 +1,50 @@
+I know an old lady who swallowed a fly.
+I don't know why she swallowed the fly. Perhaps she'll die.
+
+I know an old lady who swallowed a spider.
+It wriggled and jiggled and tickled inside her.
+She swallowed the spider to catch the fly.
+I don't know why she swallowed the fly. Perhaps she'll die.
+
+I know an old lady who swallowed a bird.
+How absurd to swallow a bird!
+She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.
+She swallowed the spider to catch the fly.
+I don't know why she swallowed the fly. Perhaps she'll die.
+
+I know an old lady who swallowed a cat.
+Imagine that, to swallow a cat!
+She swallowed the cat to catch the bird.
+She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.
+She swallowed the spider to catch the fly.
+I don't know why she swallowed the fly. Perhaps she'll die.
+
+I know an old lady who swallowed a dog.
+What a hog, to swallow a dog!
+She swallowed the dog to catch the cat.
+She swallowed the cat to catch the bird.
+She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.
+She swallowed the spider to catch the fly.
+I don't know why she swallowed the fly. Perhaps she'll die.
+
+I know an old lady who swallowed a goat.
+Just opened her throat and swallowed a goat!
+She swallowed the goat to catch the dog.
+She swallowed the dog to catch the cat.
+She swallowed the cat to catch the bird.
+She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.
+She swallowed the spider to catch the fly.
+I don't know why she swallowed the fly. Perhaps she'll die.
+
+I know an old lady who swallowed a cow.
+I don't know how she swallowed a cow!
+She swallowed the cow to catch the goat.
+She swallowed the goat to catch the dog.
+She swallowed the dog to catch the cat.
+She swallowed the cat to catch the bird.
+She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.
+She swallowed the spider to catch the fly.
+I don't know why she swallowed the fly. Perhaps she'll die.
+
+I know an old lady who swallowed a horse.
+She's dead, of course!

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -1,0 +1,35 @@
+# Gigasecond
+
+Calculate the moment when someone has lived for 10^9 seconds.
+
+A gigasecond is 10^9 (1,000,000,000) seconds.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby gigasecond_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride gigasecond_test.rb
+
+
+## Source
+
+Chapter 9 in Chris Pine's online Learn to Program tutorial. [http://pine.fm/LearnToProgram/?Chapter=09](http://pine.fm/LearnToProgram/?Chapter=09)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/gigasecond/gigasecond_test.rb
+++ b/exercises/gigasecond/gigasecond_test.rb
@@ -1,0 +1,52 @@
+require 'minitest/autorun'
+require_relative 'gigasecond'
+
+# Common test data version: 1.0.0 61e7d70
+class GigasecondTest < Minitest::Test
+  def test_date_only_specification_of_time
+    # skip
+    assert_equal Time.utc(2043, 1, 1, 1, 46, 40), Gigasecond.from(Time.utc(2011, 4, 25, 0, 0, 0))
+  end
+
+  def test_second_test_for_date_only_specification_of_time
+    skip
+    assert_equal Time.utc(2009, 2, 19, 1, 46, 40), Gigasecond.from(Time.utc(1977, 6, 13, 0, 0, 0))
+  end
+
+  def test_third_test_for_date_only_specification_of_time
+    skip
+    assert_equal Time.utc(1991, 3, 27, 1, 46, 40), Gigasecond.from(Time.utc(1959, 7, 19, 0, 0, 0))
+  end
+
+  def test_full_time_specified
+    skip
+    assert_equal Time.utc(2046, 10, 2, 23, 46, 40), Gigasecond.from(Time.utc(2015, 1, 24, 22, 0, 0))
+  end
+
+  def test_full_time_with_day_roll_over
+    skip
+    assert_equal Time.utc(2046, 10, 3, 1, 46, 39), Gigasecond.from(Time.utc(2015, 1, 24, 23, 59, 59))
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 6, BookKeeping::VERSION
+  end
+end

--- a/exercises/grade-school/README.md
+++ b/exercises/grade-school/README.md
@@ -1,0 +1,65 @@
+# Grade School
+
+Given students' names along with the grade that they are in, create a roster
+for the school.
+
+In the end, you should be able to:
+
+- Add a student's name to the roster for a grade
+  - "Add Jim to grade 2."
+  - "OK."
+- Get a list of all students enrolled in a grade
+  - "Which students are in grade 2?"
+  - "We've only got Jim just now."
+- Get a sorted list of all students in all grades.  Grades should sort
+  as 1, 2, 3, etc., and students within a grade should be sorted
+  alphabetically by name.
+  - "Who all is enrolled in school right now?"
+  - "Grade 1: Anna, Barb, and Charlie. Grade 2: Alex, Peter, and Zoe.
+    Grade 3…"
+
+Note that all our students only have one name.  (It's a small town, what
+do you want?)
+
+## For bonus points
+
+Did you get the tests passing and the code clean? If you want to, these
+are some additional things you could try:
+
+- If you're working in a language with mutable data structures and your
+  implementation allows outside code to mutate the school's internal DB
+  directly, see if you can prevent this. Feel free to introduce additional
+  tests.
+
+Then please share your thoughts in a comment on the submission. Did this
+experiment make the code better? Worse? Did you learn anything from it?
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby grade_school_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride grade_school_test.rb
+
+
+## Source
+
+A pairing session with Phil Battos at gSchool [http://gschool.it](http://gschool.it)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/grade-school/grade_school_test.rb
+++ b/exercises/grade-school/grade_school_test.rb
@@ -1,0 +1,111 @@
+require 'minitest/autorun'
+require_relative 'grade_school'
+
+class SchoolTest < Minitest::Test
+  def test_empty_grade
+    school = School.new
+    expected = []
+    assert_equal expected, school.students(1)
+  end
+
+  def test_add_student
+    skip
+    school = School.new
+    assert school.add('Aimee', 2)
+    expected = ['Aimee']
+    assert_equal expected, school.students(2)
+  end
+
+  def test_add_students_to_different_grades
+    skip
+    school = School.new
+    school.add('Aimee', 3)
+    school.add('Beemee', 7)
+    assert_equal ['Aimee'], school.students(3)
+    assert_equal ['Beemee'], school.students(7)
+  end
+
+  def test_grade_with_multiple_students
+    skip
+    school = School.new
+    grade    = 6
+    students = %w(Aimee Beemee Ceemee)
+    students.each { |student| school.add(student, grade) }
+    assert_equal students, school.students(grade)
+  end
+
+  def test_grade_with_multiple_students_sorts_correctly
+    skip
+    school = School.new
+    grade    = 6
+    students = %w(Beemee Aimee Ceemee)
+    students.each { |student| school.add(student, grade) }
+    expected = students.sort
+    assert_equal expected, school.students(grade)
+  end
+
+  def test_empty_students_by_grade
+    skip
+    school = School.new
+    expected = []
+    assert_equal expected, school.students_by_grade
+  end
+
+  def test_students_by_grade
+    skip
+    school = School.new
+    grade    = 6
+    students = %w(Beemee Aimee Ceemee)
+    students.each { |student| school.add(student, grade) }
+    expected = [{ grade: grade, students: students.sort }]
+    assert_equal expected, school.students_by_grade
+  end
+
+  def test_students_by_grade_sorted
+    skip
+    school = School.new
+    everyone.each do |grade|
+      grade[:students].each { |student| school.add(student, grade[:grade]) }
+    end
+    expected = everyone_sorted
+    assert_equal expected, school.students_by_grade
+  end
+
+  def everyone
+    [
+      { grade: 3, students: %w(Deemee Eeemee) },
+      { grade: 1, students: %w(Effmee Geemee) },
+      { grade: 2, students: %w(Aimee Beemee Ceemee) }
+    ]
+  end
+
+  def everyone_sorted
+    [
+      { grade: 1, students: %w(Effmee Geemee) },
+      { grade: 2, students: %w(Aimee Beemee Ceemee) },
+      { grade: 3, students: %w(Deemee Eeemee) }
+    ]
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 2 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 3, BookKeeping::VERSION
+  end
+end

--- a/exercises/grains/README.md
+++ b/exercises/grains/README.md
@@ -1,0 +1,57 @@
+# Grains
+
+Calculate the number of grains of wheat on a chessboard given that the number
+on each square doubles.
+
+There once was a wise servant who saved the life of a prince. The king
+promised to pay whatever the servant could dream up. Knowing that the
+king loved chess, the servant told the king he would like to have grains
+of wheat. One grain on the first square of a chess board. Two grains on
+the next. Four on the third, and so on.
+
+There are 64 squares on a chessboard.
+
+Write code that shows:
+- how many grains were on each square, and
+- the total number of grains
+
+## For bonus points
+
+Did you get the tests passing and the code clean? If you want to, these
+are some additional things you could try:
+
+- Optimize for speed.
+- Optimize for readability.
+
+Then please share your thoughts in a comment on the submission. Did this
+experiment make the code better? Worse? Did you learn anything from it?
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby grains_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride grains_test.rb
+
+
+## Source
+
+JavaRanch Cattle Drive, exercise 6 [http://www.javaranch.com/grains.jsp](http://www.javaranch.com/grains.jsp)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/grains/grains_test.rb
+++ b/exercises/grains/grains_test.rb
@@ -1,0 +1,82 @@
+require 'minitest/autorun'
+require_relative 'grains'
+
+# Common test data version: 1.0.0 2e0e77e
+class GrainsTest < Minitest::Test
+  def test_1
+    # skip
+    assert_equal 1, Grains.square(1)
+  end
+
+  def test_2
+    skip
+    assert_equal 2, Grains.square(2)
+  end
+
+  def test_3
+    skip
+    assert_equal 4, Grains.square(3)
+  end
+
+  def test_4
+    skip
+    assert_equal 8, Grains.square(4)
+  end
+
+  def test_16
+    skip
+    assert_equal 32_768, Grains.square(16)
+  end
+
+  def test_32
+    skip
+    assert_equal 2_147_483_648, Grains.square(32)
+  end
+
+  def test_64
+    skip
+    assert_equal 9_223_372_036_854_775_808, Grains.square(64)
+  end
+
+  def test_square_0_raises_an_exception
+    skip
+    assert_raises(ArgumentError) { Grains.square(0) }
+  end
+
+  def test_negative_square_raises_an_exception
+    skip
+    assert_raises(ArgumentError) { Grains.square(-1) }
+  end
+
+  def test_square_greater_than_64_raises_an_exception
+    skip
+    assert_raises(ArgumentError) { Grains.square(65) }
+  end
+
+  def test_returns_the_total_number_of_grains_on_the_board
+    skip
+    assert_equal 18_446_744_073_709_551_615, Grains.total
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -1,0 +1,66 @@
+# Hamming
+
+Calculate the Hamming difference between two DNA strands.
+
+A mutation is simply a mistake that occurs during the creation or
+copying of a nucleic acid, in particular DNA. Because nucleic acids are
+vital to cellular functions, mutations tend to cause a ripple effect
+throughout the cell. Although mutations are technically mistakes, a very
+rare mutation may equip the cell with a beneficial attribute. In fact,
+the macro effects of evolution are attributable by the accumulated
+result of beneficial microscopic mutations over many generations.
+
+The simplest and most common type of nucleic acid mutation is a point
+mutation, which replaces one base with another at a single nucleotide.
+
+By counting the number of differences between two homologous DNA strands
+taken from different genomes with a common ancestor, we get a measure of
+the minimum number of point mutations that could have occurred on the
+evolutionary path between the two strands.
+
+This is called the 'Hamming distance'.
+
+It is found by comparing two DNA strands and counting how many of the
+nucleotides are different from their equivalent in the other string.
+
+    GAGCCTACTAACGGGAT
+    CATCGTAATGACGGCCT
+    ^ ^ ^  ^ ^    ^^
+
+The Hamming distance between these two DNA strands is 7.
+
+# Implementation notes
+
+The Hamming distance is only defined for sequences of equal length. This means
+that based on the definition, each language could deal with getting sequences
+of equal length differently.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby hamming_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride hamming_test.rb
+
+
+## Source
+
+The Calculating Point Mutations problem at Rosalind [http://rosalind.info/problems/hamm/](http://rosalind.info/problems/hamm/)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/hamming/RUNNING_TESTS.md
+++ b/exercises/hamming/RUNNING_TESTS.md
@@ -1,0 +1,56 @@
+# Running Tests
+
+In order to complete this exercise, and all of the subsequent exercises, you
+will need to pass multiple tests.
+
+## Understanding Test Results
+
+After you have created and saved `hamming.rb`, run the test suite. You should
+see output like the following:
+
+    # Running:
+
+    SSSSSSESSSSSSSSS
+
+    Finished in 0.002593s, 6170.4588 runs/s, 0.0000 assertions/s.
+
+      1) Error:
+    HammingTest#test_identical_strands:
+    NameError: uninitialized constant HammingTest::Hamming
+    Did you mean?  HammingTest
+        ../hamming/hamming_test.rb:9:in `test_identical_strands'
+
+    16 runs, 0 assertions, 0 failures, 1 errors, 15 skips
+
+    You have skipped tests. Run with --verbose for details.
+
+
+The letters `SSSSSSESSSSSSSSS` show that there are sixteen tests altogether,
+that one of them has an error (`E`), and that the rest of them are skipped (all
+the `S` letters).
+
+The tests are run in randomized order, which will cause the letters to display
+in random order as well.
+
+The goal is to have all passing tests, which will show in two places:
+
+1. `SSSSSSESSSSSSSSS` will become a series dots: `................`, 
+
+2. The line at the bottom will read `16 runs, 0 assertions, 0 failures, 0
+   errors, 0 skips`.
+
+## Passing Tests
+
+Write enough code to change the Error to Failure, and finally to Passing.
+
+Open `hamming_test.rb`, and find the word "skip". All but the first test start
+with "skip", which tells Minitest to ignore the test. This is so that you don't
+have to deal with all the failures at once.
+
+To activate the next test, delete the "skip", or comment it out, and run the
+test suite again.
+
+## Wash, Rinse, Repeat
+
+Delete one "skip" at a time, and make each test pass before you move to the
+next one.

--- a/exercises/hamming/hamming_test.rb
+++ b/exercises/hamming/hamming_test.rb
@@ -1,0 +1,102 @@
+require 'minitest/autorun'
+require_relative 'hamming'
+
+# Common test data version: 2.0.1 f79dfd7
+class HammingTest < Minitest::Test
+  def test_empty_strands
+    # skip
+    assert_equal 0, Hamming.compute('', '')
+  end
+
+  def test_identical_strands
+    skip
+    assert_equal 0, Hamming.compute('A', 'A')
+  end
+
+  def test_long_identical_strands
+    skip
+    assert_equal 0, Hamming.compute('GGACTGA', 'GGACTGA')
+  end
+
+  def test_complete_distance_in_single_nucleotide_strands
+    skip
+    assert_equal 1, Hamming.compute('A', 'G')
+  end
+
+  def test_complete_distance_in_small_strands
+    skip
+    assert_equal 2, Hamming.compute('AG', 'CT')
+  end
+
+  def test_small_distance_in_small_strands
+    skip
+    assert_equal 1, Hamming.compute('AT', 'CT')
+  end
+
+  def test_small_distance
+    skip
+    assert_equal 1, Hamming.compute('GGACG', 'GGTCG')
+  end
+
+  def test_small_distance_in_long_strands
+    skip
+    assert_equal 2, Hamming.compute('ACCAGGG', 'ACTATGG')
+  end
+
+  def test_non_unique_character_in_first_strand
+    skip
+    assert_equal 1, Hamming.compute('AAG', 'AAA')
+  end
+
+  def test_non_unique_character_in_second_strand
+    skip
+    assert_equal 1, Hamming.compute('AAA', 'AAG')
+  end
+
+  def test_same_nucleotides_in_different_positions
+    skip
+    assert_equal 2, Hamming.compute('TAG', 'GAT')
+  end
+
+  def test_large_distance
+    skip
+    assert_equal 4, Hamming.compute('GATACA', 'GCATAA')
+  end
+
+  def test_large_distance_in_off_by_one_strand
+    skip
+    assert_equal 9, Hamming.compute('GGACGGATTCTG', 'AGGACGGATTCT')
+  end
+
+  def test_disallow_first_strand_longer
+    skip
+    assert_raises(ArgumentError) { Hamming.compute('AATG', 'AAA') }
+  end
+
+  def test_disallow_second_strand_longer
+    skip
+    assert_raises(ArgumentError) { Hamming.compute('ATA', 'AGTG') }
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 3, BookKeeping::VERSION
+  end
+end

--- a/exercises/hello-world/GETTING_STARTED.md
+++ b/exercises/hello-world/GETTING_STARTED.md
@@ -1,0 +1,128 @@
+# Getting Started
+
+These exercises lean on Test-Driven Development (TDD), but they're not an
+exact match. If you want a gentle introduction to TDD using minitest in
+Ruby, see the "Intro to TDD" over at JumpstartLab:
+http://tutorials.jumpstartlab.com/topics/testing/intro-to-tdd.html
+
+The following steps assume that you are in the same directory as the test
+suite.
+
+You must have the `minitest` gem installed:
+
+    $ gem install minitest
+
+## Step 1
+
+Run the test suite. It's written using the Minitest framework, and can be
+run with ruby:
+
+    $ ruby hello_world_test.rb
+
+This will fail, complaining that there is no file called `hello_world`.
+
+To fix the error create an empty file called `hello_world.rb` in the same
+directory as the `hello_world_test.rb` file.
+
+## Step 2
+
+Run the test again. It will give you a new error, since now the file exists,
+but is empty and does not contain the expected code.
+
+Depending on what platform you are on, the error will look different, but
+the way to fix it will be the same.
+
+On Windows, it will complain about:
+
+    syntax error, unexpected end-of-input, expecting '('
+
+On OS X and Linux, the error will be something like:
+
+
+    # Running:
+
+    E
+
+    Finished in 0.001328s, 753.0121 runs/s, 0.0000 assertions/s.
+
+      1) Error:
+    HelloWorldTest#test_say_hi:
+    NameError: uninitialized constant HelloWorldTest::HelloWorld
+    Did you mean?  HelloWorldTest
+        hello_world_test.rb:19:in `test_say_hi'
+
+    1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
+
+
+Within the first test, we are referencing a constant named `HelloWorld` when
+we say `HelloWorld.hello`. When Ruby sees a capitalized name like
+`HelloWorld`, it looks it up in a big huge list of all the constants it knows about,
+to see what it points to. It could point to anything, and often in Ruby we have
+constants that point to definitions of classes or modules.
+
+When it looks `HelloWorld` up in its list, it doesn't find anything, so we need
+to make one.
+
+### Fixing the Error
+
+To fix it, open up the hello_world.rb file and add the following code:
+
+    class HelloWorld
+    end
+
+## Step 3
+
+Run the test again.
+
+    1) Error:
+    HelloWorldTest#test_no_name:
+    NoMethodError: undefined method `hello' for HelloWorld:Class
+        hello_world_test.rb:20:in `test_no_name'
+
+This time we have a `HelloWorld`, but we're trying tell it to `hello`, and
+`HelloWorld` doesn't understand that message.
+
+Open up hello_world.rb and add a method definition inside the class:
+
+    class HelloWorld
+      def self.hello
+      end
+    end
+
+## Step 4
+
+Run the test again.
+
+    1) Failure:
+    HelloWorldTest#test_no_name [hello_world_test.rb:11]:
+    When given no name, we should greet the world.
+    Expected: "Hello, World!"
+      Actual: nil
+
+Up until now we've been getting errors, this time we get a failure.
+
+An error means that Ruby cannot even run properly because of things like missing
+files or syntax errors, or referring to things that don't exist.
+
+A failure is different. A failure is when Ruby is running just fine
+and the test is expecting one outcome, but getting another.
+
+The test is expecting the `hello` method to return the string `"Hello, World!"`. The easiest way
+to make it pass, is to simply stick the string `"Hello, World!"` inside the method definition.
+
+## Step 5
+
+Run the test again.
+
+If it fails you're going to need to read the error message carefully to figure
+out what went wrong, and then try again.
+
+If it passes, then you're ready to move to the next step.
+
+## Submit
+
+When everything is passing, you can submit your code with the following
+command:
+
+    $ exercism submit hello_world.rb
+

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -1,0 +1,45 @@
+# Hello World
+
+The classical introductory exercise. Just say "Hello, World!".
+
+["Hello, World!"](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program) is
+the traditional first program for beginning programming in a new language
+or environment.
+
+The objectives are simple:
+
+- Write a function that returns the string "Hello, World!".
+- Run the test suite and make sure that it succeeds.
+- Submit your solution and check it at the website.
+
+If everything goes well, you will be ready to fetch your first real exercise.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby hello_world_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride hello_world_test.rb
+
+
+## Source
+
+This is an exercise to introduce users to using Exercism [http://en.wikipedia.org/wiki/%22Hello,_world!%22_program](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/hello-world/hello_world_test.rb
+++ b/exercises/hello-world/hello_world_test.rb
@@ -1,0 +1,43 @@
+begin
+  gem 'minitest', '>= 5.0.0'
+  require 'minitest/autorun'
+  require_relative 'hello_world'
+rescue Gem::LoadError => e
+  puts "\nMissing Dependency:\n#{e.backtrace.first} #{e.message}"
+  puts 'Minitest 5.0 gem must be installed for the Ruby track.'
+rescue LoadError => e
+  puts "\nError:\n#{e.backtrace.first} #{e.message}"
+  puts DATA.read
+  exit 1
+end
+
+# Common test data version: 1.0.0 4b9ae53
+class HelloWorldTest < Minitest::Test
+  def test_say_hi
+    # skip
+    assert_equal "Hello, World!", HelloWorld.hello
+  end
+end
+
+__END__
+
+*****************************************************
+You got an error, which is exactly as it should be.
+This is the first step in the Test-Driven Development
+(TDD) process.
+
+The most important part of the error is
+
+   cannot load such file
+
+It's looking for a file named hello_world.rb that doesn't
+exist yet.
+
+To fix the error, create an empty file named hello_world.rb
+in the same directory as the hello_world_test.rb file.
+
+Then run the test again.
+
+For more guidance as you work on this exercise, see
+GETTING_STARTED.md.
+*****************************************************

--- a/exercises/hexadecimal/README.md
+++ b/exercises/hexadecimal/README.md
@@ -1,0 +1,38 @@
+# Hexadecimal
+
+Convert a hexadecimal number, represented as a string (e.g. "10af8c"), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).
+
+On the web we use hexadecimal to represent colors, e.g. green: 008000,
+teal: 008080, navy: 000080).
+
+The program should handle invalid hexadecimal strings.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby hexadecimal_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride hexadecimal_test.rb
+
+
+## Source
+
+All of Computer Science [http://www.wolframalpha.com/examples/NumberBases.html](http://www.wolframalpha.com/examples/NumberBases.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/hexadecimal/hexadecimal_test.rb
+++ b/exercises/hexadecimal/hexadecimal_test.rb
@@ -1,0 +1,53 @@
+require 'minitest/autorun'
+require_relative 'hexadecimal'
+
+class HexadecimalTest < Minitest::Test
+  def test_hex_1_is_decimal_1
+    assert_equal 1, Hexadecimal.new('1').to_decimal
+  end
+
+  def test_hex_c_is_decimal_12
+    skip
+    assert_equal 12, Hexadecimal.new('c').to_decimal
+  end
+
+  def test_hex_10_is_decimal_16
+    skip
+    assert_equal 16, Hexadecimal.new('10').to_decimal
+  end
+
+  def test_hex_af_is_decimal_175
+    skip
+    assert_equal 175, Hexadecimal.new('af').to_decimal
+  end
+
+  def test_hex_100_is_decimal_256
+    skip
+    assert_equal 256, Hexadecimal.new('100').to_decimal
+  end
+
+  def test_hex_19ace_is_decimal_105166
+    skip
+    assert_equal 105_166, Hexadecimal.new('19ace').to_decimal
+  end
+
+  def test_invalid_hex_is_decimal_0
+    skip
+    assert_equal 0, Hexadecimal.new('carrot').to_decimal
+  end
+
+  def test_black
+    skip
+    assert_equal 0, Hexadecimal.new('000000').to_decimal
+  end
+
+  def test_white
+    skip
+    assert_equal 16_777_215, Hexadecimal.new('ffffff').to_decimal
+  end
+
+  def test_yellow
+    skip
+    assert_equal 16_776_960, Hexadecimal.new('ffff00').to_decimal
+  end
+end

--- a/exercises/house/README.md
+++ b/exercises/house/README.md
@@ -1,0 +1,136 @@
+# House
+
+Recite the nursery rhyme 'This is the House that Jack Built'.
+
+> [The] process of placing a phrase of clause within another phrase of
+> clause is called embedding. It is through the processes of recursion
+> and embedding that we are able to take a finite number of forms (words
+> and phrases) and construct an infinite number of expressions.
+> Furthermore, embedding also allows us to construct an infinitely long
+> structure, in theory anyway.
+
+- [papyr.com](http://papyr.com/hypertextbooks/grammar/ph_noun.htm)
+
+The nursery rhyme reads as follows:
+
+```text
+This is the house that Jack built.
+
+This is the malt
+that lay in the house that Jack built.
+
+This is the rat
+that ate the malt
+that lay in the house that Jack built.
+
+This is the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
+
+This is the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
+
+This is the cow with the crumpled horn
+that tossed the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
+
+This is the maiden all forlorn
+that milked the cow with the crumpled horn
+that tossed the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
+
+This is the man all tattered and torn
+that kissed the maiden all forlorn
+that milked the cow with the crumpled horn
+that tossed the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
+
+This is the priest all shaven and shorn
+that married the man all tattered and torn
+that kissed the maiden all forlorn
+that milked the cow with the crumpled horn
+that tossed the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
+
+This is the rooster that crowed in the morn
+that woke the priest all shaven and shorn
+that married the man all tattered and torn
+that kissed the maiden all forlorn
+that milked the cow with the crumpled horn
+that tossed the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
+
+This is the farmer sowing his corn
+that kept the rooster that crowed in the morn
+that woke the priest all shaven and shorn
+that married the man all tattered and torn
+that kissed the maiden all forlorn
+that milked the cow with the crumpled horn
+that tossed the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
+
+This is the horse and the hound and the horn
+that belonged to the farmer sowing his corn
+that kept the rooster that crowed in the morn
+that woke the priest all shaven and shorn
+that married the man all tattered and torn
+that kissed the maiden all forlorn
+that milked the cow with the crumpled horn
+that tossed the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
+```
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby house_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride house_test.rb
+
+
+## Source
+
+British nursery rhyme [http://en.wikipedia.org/wiki/This_Is_The_House_That_Jack_Built](http://en.wikipedia.org/wiki/This_Is_The_House_That_Jack_Built)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/house/house_test.rb
+++ b/exercises/house/house_test.rb
@@ -1,0 +1,99 @@
+require 'minitest/autorun'
+require_relative 'house'
+
+class HouseTest < Minitest::Test
+  def test_rhyme
+    expected = <<-RHYME
+This is the house that Jack built.
+
+This is the malt
+that lay in the house that Jack built.
+
+This is the rat
+that ate the malt
+that lay in the house that Jack built.
+
+This is the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
+
+This is the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
+
+This is the cow with the crumpled horn
+that tossed the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
+
+This is the maiden all forlorn
+that milked the cow with the crumpled horn
+that tossed the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
+
+This is the man all tattered and torn
+that kissed the maiden all forlorn
+that milked the cow with the crumpled horn
+that tossed the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
+
+This is the priest all shaven and shorn
+that married the man all tattered and torn
+that kissed the maiden all forlorn
+that milked the cow with the crumpled horn
+that tossed the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
+
+This is the rooster that crowed in the morn
+that woke the priest all shaven and shorn
+that married the man all tattered and torn
+that kissed the maiden all forlorn
+that milked the cow with the crumpled horn
+that tossed the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
+
+This is the farmer sowing his corn
+that kept the rooster that crowed in the morn
+that woke the priest all shaven and shorn
+that married the man all tattered and torn
+that kissed the maiden all forlorn
+that milked the cow with the crumpled horn
+that tossed the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
+
+This is the horse and the hound and the horn
+that belonged to the farmer sowing his corn
+that kept the rooster that crowed in the morn
+that woke the priest all shaven and shorn
+that married the man all tattered and torn
+that kissed the maiden all forlorn
+that milked the cow with the crumpled horn
+that tossed the dog
+that worried the cat
+that killed the rat
+that ate the malt
+that lay in the house that Jack built.
+    RHYME
+    assert_equal expected, House.recite
+  end
+end

--- a/exercises/isbn-verifier/README.md
+++ b/exercises/isbn-verifier/README.md
@@ -1,0 +1,71 @@
+# ISBN Verifier
+
+The [ISBN-10 verification process](https://en.wikipedia.org/wiki/International_Standard_Book_Number) is used to validate book identification
+numbers. These normally contain dashes and look like: `3-598-21508-8`
+
+## ISBN
+
+The ISBN-10 format is 9 digits (0 to 9) plus one check character (either a digit or an X only). In the case the check character is an X, this represents the value '10'. These may be communicated with or without hyphens, and can be checked for their validity by the following formula:
+
+```
+(x1 * 10 + x2 * 9 + x3 * 8 + x4 * 7 + x5 * 6 + x6 * 5 + x7 * 4 + x8 * 3 + x9 * 2 + x10 * 1) mod 11 == 0
+```
+
+If the result is 0, then it is a valid ISBN-10, otherwise it is invalid.
+
+## Example
+
+Let's take the ISBN-10 `3-598-21508-8`. We plug it in to the formula, and get:
+```
+(3 * 10 + 5 * 9 + 9 * 8 + 8 * 7 + 2 * 6 + 1 * 5 + 5 * 4 + 0 * 3 + 8 * 2 + 8 * 1) mod 11 == 0
+```
+
+Since the result is 0, this proves that our ISBN is valid.
+
+## Task
+
+Given a string the program should check if the provided string is a valid ISBN-10.
+Putting this into place requires some thinking about preprocessing/parsing of the string prior to calculating the check digit for the ISBN.
+
+The program should be able to verify ISBN-10 both with and without separating dashes.
+
+
+## Caveats
+
+Converting from strings to numbers can be tricky in certain languages.
+Now, it's even trickier since the check digit of an ISBN-10 may be 'X' (representing '10'). For instance `3-598-21507-X` is a valid ISBN-10.
+
+## Bonus tasks
+
+* Generate a valid ISBN-13 from the input ISBN-10 (and maybe verify it again with a derived verifier).
+
+* Generate valid ISBN, maybe even from a given starting ISBN.
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby isbn_verifier_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride isbn_verifier_test.rb
+
+
+## Source
+
+Converting a string into a number and some basic processing utilizing a relatable real world example. [https://en.wikipedia.org/wiki/International_Standard_Book_Number#ISBN-10_check_digit_calculation](https://en.wikipedia.org/wiki/International_Standard_Book_Number#ISBN-10_check_digit_calculation)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/isbn-verifier/isbn_verifier_test.rb
+++ b/exercises/isbn-verifier/isbn_verifier_test.rb
@@ -1,0 +1,105 @@
+require 'minitest/autorun'
+require_relative 'isbn_verifier'
+
+# Common test data version: 2.0.0 3251fa6
+class IsbnVerifierTest < Minitest::Test
+  def test_valid_isbn_number
+    # skip
+    string = "3-598-21508-8"
+    assert IsbnVerifier.valid?(string), "Expected true, '#{string}' is a valid isbn"
+  end
+
+  def test_invalid_isbn_check_digit
+    skip
+    string = "3-598-21508-9"
+    refute IsbnVerifier.valid?(string), "Expected false, '#{string}' is not a valid isbn"
+  end
+
+  def test_valid_isbn_number_with_a_check_digit_of_10
+    skip
+    string = "3-598-21507-X"
+    assert IsbnVerifier.valid?(string), "Expected true, '#{string}' is a valid isbn"
+  end
+
+  def test_check_digit_is_a_character_other_than_x
+    skip
+    string = "3-598-21507-A"
+    refute IsbnVerifier.valid?(string), "Expected false, '#{string}' is not a valid isbn"
+  end
+
+  def test_invalid_character_in_isbn
+    skip
+    string = "3-598-2K507-0"
+    refute IsbnVerifier.valid?(string), "Expected false, '#{string}' is not a valid isbn"
+  end
+
+  def test_x_is_only_valid_as_a_check_digit
+    skip
+    string = "3-598-2X507-9"
+    refute IsbnVerifier.valid?(string), "Expected false, '#{string}' is not a valid isbn"
+  end
+
+  def test_valid_isbn_without_separating_dashes
+    skip
+    string = "3598215088"
+    assert IsbnVerifier.valid?(string), "Expected true, '#{string}' is a valid isbn"
+  end
+
+  def test_isbn_without_separating_dashes_and_x_as_check_digit
+    skip
+    string = "359821507X"
+    assert IsbnVerifier.valid?(string), "Expected true, '#{string}' is a valid isbn"
+  end
+
+  def test_isbn_without_check_digit_and_dashes
+    skip
+    string = "359821507"
+    refute IsbnVerifier.valid?(string), "Expected false, '#{string}' is not a valid isbn"
+  end
+
+  def test_too_long_isbn_and_no_dashes
+    skip
+    string = "3598215078X"
+    refute IsbnVerifier.valid?(string), "Expected false, '#{string}' is not a valid isbn"
+  end
+
+  def test_isbn_without_check_digit
+    skip
+    string = "3-598-21507"
+    refute IsbnVerifier.valid?(string), "Expected false, '#{string}' is not a valid isbn"
+  end
+
+  def test_too_long_isbn
+    skip
+    string = "3-598-21507-XX"
+    refute IsbnVerifier.valid?(string), "Expected false, '#{string}' is not a valid isbn"
+  end
+
+  def test_check_digit_of_x_should_not_be_used_for_0
+    skip
+    string = "3-598-21515-X"
+    refute IsbnVerifier.valid?(string), "Expected false, '#{string}' is not a valid isbn"
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/isogram/README.md
+++ b/exercises/isogram/README.md
@@ -1,0 +1,44 @@
+# Isogram
+
+Determine if a word or phrase is an isogram.
+
+An isogram (also known as a "nonpattern word") is a word or phrase without a repeating letter, however spaces and hyphens are allowed to appear multiple times.
+
+Examples of isograms:
+
+- lumberjacks
+- background
+- downstream
+- six-year-old
+
+The word *isograms*, however, is not an isogram, because the s repeats.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby isogram_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride isogram_test.rb
+
+
+## Source
+
+Wikipedia [https://en.wikipedia.org/wiki/Isogram](https://en.wikipedia.org/wiki/Isogram)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/isogram/isogram_test.rb
+++ b/exercises/isogram/isogram_test.rb
@@ -1,0 +1,81 @@
+require 'minitest/autorun'
+require_relative 'isogram'
+
+# Common test data version: 1.2.0 f9e0ebb
+class IsogramTest < Minitest::Test
+  def test_empty_string
+    # skip
+    input = ""
+    assert Isogram.isogram?(input), "Expected true, '#{input}' is an isogram"
+  end
+
+  def test_isogram_with_only_lower_case_characters
+    skip
+    input = "isogram"
+    assert Isogram.isogram?(input), "Expected true, '#{input}' is an isogram"
+  end
+
+  def test_word_with_one_duplicated_character
+    skip
+    input = "eleven"
+    refute Isogram.isogram?(input), "Expected false, '#{input}' is not an isogram"
+  end
+
+  def test_longest_reported_english_isogram
+    skip
+    input = "subdermatoglyphic"
+    assert Isogram.isogram?(input), "Expected true, '#{input}' is an isogram"
+  end
+
+  def test_word_with_duplicated_character_in_mixed_case
+    skip
+    input = "Alphabet"
+    refute Isogram.isogram?(input), "Expected false, '#{input}' is not an isogram"
+  end
+
+  def test_hypothetical_isogrammic_word_with_hyphen
+    skip
+    input = "thumbscrew-japingly"
+    assert Isogram.isogram?(input), "Expected true, '#{input}' is an isogram"
+  end
+
+  def test_isogram_with_duplicated_hyphen
+    skip
+    input = "six-year-old"
+    assert Isogram.isogram?(input), "Expected true, '#{input}' is an isogram"
+  end
+
+  def test_made_up_name_that_is_an_isogram
+    skip
+    input = "Emily Jung Schwartzkopf"
+    assert Isogram.isogram?(input), "Expected true, '#{input}' is an isogram"
+  end
+
+  def test_duplicated_character_in_the_middle
+    skip
+    input = "accentor"
+    refute Isogram.isogram?(input), "Expected false, '#{input}' is not an isogram"
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 4, BookKeeping::VERSION
+  end
+end

--- a/exercises/kindergarten-garden/README.md
+++ b/exercises/kindergarten-garden/README.md
@@ -1,0 +1,90 @@
+# Kindergarten Garden
+
+Given a diagram, determine which plants each child in the kindergarten class is
+responsible for.
+
+The kindergarten class is learning about growing plants. The teacher
+thought it would be a good idea to give them actual seeds, plant them in
+actual dirt, and grow actual plants.
+
+They've chosen to grow grass, clover, radishes, and violets.
+
+To this end, the children have put little cups along the window sills, and
+planted one type of plant in each cup, choosing randomly from the available
+types of seeds.
+
+```text
+[window][window][window]
+........................ # each dot represents a cup
+........................
+```
+
+There are 12 children in the class:
+
+- Alice, Bob, Charlie, David,
+- Eve, Fred, Ginny, Harriet,
+- Ileana, Joseph, Kincaid, and Larry.
+
+Each child gets 4 cups, two on each row. Their teacher assigns cups to
+the children alphabetically by their names.
+
+The following diagram represents Alice's plants:
+
+```text
+[window][window][window]
+VR......................
+RG......................
+```
+
+In the first row, nearest the windows, she has a violet and a radish.  In the
+second row she has a radish and some grass.
+
+Your program will be given the plants from left-to-right starting with
+the row nearest the windows. From this, it should be able to determine
+which plants belong to each student.
+
+For example, if it's told that the garden looks like so:
+
+```text
+[window][window][window]
+VRCGVVRVCGGCCGVRGCVCGCGV
+VRCCCGCRRGVCGCRVVCVGCGCV
+```
+
+Then if asked for Alice's plants, it should provide:
+
+- Violets, radishes, violets, radishes
+
+While asking for Bob's plants would yield:
+
+- Clover, grass, clover, clover
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby kindergarten_garden_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride kindergarten_garden_test.rb
+
+
+## Source
+
+Random musings during airplane trip. [http://jumpstartlab.com](http://jumpstartlab.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/kindergarten-garden/kindergarten_garden_test.rb
+++ b/exercises/kindergarten-garden/kindergarten_garden_test.rb
@@ -1,0 +1,151 @@
+require 'minitest/autorun'
+require_relative 'kindergarten_garden'
+
+class GardenTest < Minitest::Test
+  def test_alices_garden
+    garden = Garden.new("RC\nGG")
+    assert_equal [:radishes, :clover, :grass, :grass], garden.alice
+  end
+
+  def test_different_garden_for_alice
+    skip
+    garden = Garden.new("VC\nRC")
+    assert_equal [:violets, :clover, :radishes, :clover], garden.alice
+  end
+
+  def test_bobs_garden
+    skip
+    garden = Garden.new("VVCG\nVVRC")
+    assert_equal [:clover, :grass, :radishes, :clover], garden.bob
+  end
+
+  def test_bob_and_charlies_gardens
+    skip
+    garden = Garden.new("VVCCGG\nVVCCGG")
+    assert_equal [:clover, :clover, :clover, :clover], garden.bob
+    assert_equal [:grass, :grass, :grass, :grass], garden.charlie
+  end
+end
+
+class TestFullGarden < Minitest::Test
+  def setup
+    skip
+    diagram = "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"
+    @garden = Garden.new(diagram)
+  end
+
+  attr_reader :garden
+
+  def test_alice
+    skip
+    assert_equal [:violets, :radishes, :violets, :radishes], garden.alice
+  end
+
+  def test_bob
+    skip
+    assert_equal [:clover, :grass, :clover, :clover], garden.bob
+  end
+
+  def test_charlie
+    skip
+    assert_equal [:violets, :violets, :clover, :grass], garden.charlie
+  end
+
+  def test_david
+    skip
+    assert_equal [:radishes, :violets, :clover, :radishes], garden.david
+  end
+
+  def test_eve
+    skip
+    assert_equal [:clover, :grass, :radishes, :grass], garden.eve
+  end
+
+  def test_fred
+    skip
+    assert_equal [:grass, :clover, :violets, :clover], garden.fred
+  end
+
+  def test_ginny
+    skip
+    assert_equal [:clover, :grass, :grass, :clover], garden.ginny
+  end
+
+  def test_harriet
+    skip
+    assert_equal [:violets, :radishes, :radishes, :violets], garden.harriet
+  end
+
+  def test_ileana
+    skip
+    assert_equal [:grass, :clover, :violets, :clover], garden.ileana
+  end
+
+  def test_joseph
+    skip
+    assert_equal [:violets, :clover, :violets, :grass], garden.joseph
+  end
+
+  def test_kincaid
+    skip
+    assert_equal [:grass, :clover, :clover, :grass], garden.kincaid
+  end
+
+  def test_larry
+    skip
+    assert_equal [:grass, :violets, :clover, :violets], garden.larry
+  end
+end
+
+class DisorderedTest < Minitest::Test
+  def setup
+    skip
+    diagram = "VCRRGVRG\nRVGCCGCV"
+    students = %w(Samantha Patricia Xander Roger)
+    @garden = Garden.new(diagram, students)
+  end
+
+  attr_reader :garden
+
+  def test_patricia
+    skip
+    assert_equal [:violets, :clover, :radishes, :violets], garden.patricia
+  end
+
+  def test_roger
+    skip
+    assert_equal [:radishes, :radishes, :grass, :clover], garden.roger
+  end
+
+  def test_samantha
+    skip
+    assert_equal [:grass, :violets, :clover, :grass], garden.samantha
+  end
+
+  def test_xander
+    skip
+    assert_equal [:radishes, :grass, :clover, :violets], garden.xander
+  end
+end
+
+class TwoGardensDifferentStudents < Minitest::Test
+  def diagram
+    "VCRRGVRG\nRVGCCGCV"
+  end
+
+  def garden_1
+    @garden_1 ||= Garden.new(diagram, %w(Alice Bob Charlie Dan))
+  end
+
+  def garden_2
+    @garden_2 ||= Garden.new(diagram, %w(Bob Charlie Dan Erin))
+  end
+
+  def test_bob_and_charlie_per_garden
+    skip
+    assert_equal [:radishes, :radishes, :grass, :clover], garden_1.bob
+    assert_equal [:violets, :clover, :radishes, :violets], garden_2.bob
+    assert_equal [:grass, :violets, :clover, :grass], garden_1.charlie
+    assert_equal [:radishes, :radishes, :grass, :clover], garden_2.charlie
+  end
+end

--- a/exercises/largest-series-product/README.md
+++ b/exercises/largest-series-product/README.md
@@ -1,0 +1,44 @@
+# Largest Series Product
+
+Given a string of digits, calculate the largest product for a contiguous
+substring of digits of length n.
+
+For example, for the input `'1027839564'`, the largest product for a
+series of 3 digits is 270 (9 * 5 * 6), and the largest product for a
+series of 5 digits is 7560 (7 * 8 * 3 * 9 * 5).
+
+Note that these series are only required to occupy *adjacent positions*
+in the input; the digits need not be *numerically consecutive*.
+
+For the input `'73167176531330624919225119674426574742355349194934'`,
+the largest product for a series of 6 digits is 23520.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby largest_series_product_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride largest_series_product_test.rb
+
+
+## Source
+
+A variation on Problem 8 at Project Euler [http://projecteuler.net/problem=8](http://projecteuler.net/problem=8)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/largest-series-product/largest_series_product_test.rb
+++ b/exercises/largest-series-product/largest_series_product_test.rb
@@ -1,0 +1,102 @@
+require 'minitest/autorun'
+require_relative 'largest_series_product'
+
+# Common test data version: 1.0.0 e79b832
+class LargestSeriesProductTest < Minitest::Test
+  def test_finds_the_largest_product_if_span_equals_length
+    # skip
+    assert_equal 18, Series.new('29').largest_product(2)
+  end
+
+  def test_can_find_the_largest_product_of_2_with_numbers_in_order
+    skip
+    assert_equal 72, Series.new('0123456789').largest_product(2)
+  end
+
+  def test_can_find_the_largest_product_of_2
+    skip
+    assert_equal 48, Series.new('576802143').largest_product(2)
+  end
+
+  def test_can_find_the_largest_product_of_3_with_numbers_in_order
+    skip
+    assert_equal 504, Series.new('0123456789').largest_product(3)
+  end
+
+  def test_can_find_the_largest_product_of_3
+    skip
+    assert_equal 270, Series.new('1027839564').largest_product(3)
+  end
+
+  def test_can_find_the_largest_product_of_5_with_numbers_in_order
+    skip
+    assert_equal 15120, Series.new('0123456789').largest_product(5)
+  end
+
+  def test_can_get_the_largest_product_of_a_big_number
+    skip
+    assert_equal 23520, Series.new('73167176531330624919225119674426574742355349194934').largest_product(6)
+  end
+
+  def test_reports_zero_if_the_only_digits_are_zero
+    skip
+    assert_equal 0, Series.new('0000').largest_product(2)
+  end
+
+  def test_reports_zero_if_all_spans_include_zero
+    skip
+    assert_equal 0, Series.new('99099').largest_product(3)
+  end
+
+  def test_rejects_span_longer_than_string_length
+    skip
+    assert_raises(ArgumentError) { Series.new('123').largest_product(4) }
+  end
+
+  def test_reports_1_for_empty_string_and_empty_product_0_span
+    skip
+    assert_equal 1, Series.new('').largest_product(0)
+  end
+
+  def test_reports_1_for_nonempty_string_and_empty_product_0_span
+    skip
+    assert_equal 1, Series.new('123').largest_product(0)
+  end
+
+  def test_rejects_empty_string_and_nonzero_span
+    skip
+    assert_raises(ArgumentError) { Series.new('').largest_product(1) }
+  end
+
+  def test_rejects_invalid_character_in_digits
+    skip
+    assert_raises(ArgumentError) { Series.new('1234a5').largest_product(2) }
+  end
+
+  def test_rejects_negative_span
+    skip
+    assert_raises(ArgumentError) { Series.new('12345').largest_product(-1) }
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 3, BookKeeping::VERSION
+  end
+end

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -1,0 +1,57 @@
+# Leap
+
+Given a year, report if it is a leap year.
+
+The tricky thing here is that a leap year in the Gregorian calendar occurs:
+
+```text
+on every year that is evenly divisible by 4
+  except every year that is evenly divisible by 100
+    unless the year is also evenly divisible by 400
+```
+
+For example, 1997 is not a leap year, but 1996 is.  1900 is not a leap
+year, but 2000 is.
+
+If your language provides a method in the standard library that does
+this look-up, pretend it doesn't exist and implement it yourself.
+
+## Notes
+
+Though our exercise adopts some very simple rules, there is more to
+learn!
+
+For a delightful, four minute explanation of the whole leap year
+phenomenon, go watch [this youtube video][video].
+
+[video]: http://www.youtube.com/watch?v=xX96xng7sAE
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby leap_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride leap_test.rb
+
+
+## Source
+
+JavaRanch Cattle Drive, exercise 3 [http://www.javaranch.com/leap.jsp](http://www.javaranch.com/leap.jsp)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/leap/leap_test.rb
+++ b/exercises/leap/leap_test.rb
@@ -1,0 +1,56 @@
+require 'minitest/autorun'
+require_relative 'leap'
+
+# Common test data version: 1.1.0 7f4d0d8
+class Date
+  def leap?
+    raise RuntimeError, "Implement this yourself instead of using Ruby's implementation."
+  end
+
+  alias gregorian_leap? leap?
+  alias julian_leap? leap?
+end
+
+class YearTest < Minitest::Test
+  def test_year_not_divisible_by_4_common_year
+    # skip
+    refute Year.leap?(2015), "Expected 'false', 2015 is not a leap year."
+  end
+
+  def test_year_divisible_by_4_not_divisible_by_100_leap_year
+    skip
+    assert Year.leap?(2020), "Expected 'true', 2020 is a leap year."
+  end
+
+  def test_year_divisible_by_100_not_divisible_by_400_common_year
+    skip
+    refute Year.leap?(2100), "Expected 'false', 2100 is not a leap year."
+  end
+
+  def test_year_divisible_by_400_leap_year
+    skip
+    assert Year.leap?(2000), "Expected 'true', 2000 is a leap year."
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 3, BookKeeping::VERSION
+  end
+end

--- a/exercises/linked-list/README.md
+++ b/exercises/linked-list/README.md
@@ -1,0 +1,58 @@
+# Linked List
+
+Implement a doubly linked list.
+
+Like an array, a linked list is a simple linear data structure. Several
+common data types can be implemented using linked lists, like queues,
+stacks, and associative arrays.
+
+A linked list is a collection of data elements called *nodes*. In a
+*singly linked list* each node holds a value and a link to the next node.
+In a *doubly linked list* each node also holds a link to the previous
+node.
+
+You will write an implementation of a doubly linked list. Implement a
+Node to hold a value and pointers to the next and previous nodes. Then
+implement a List which holds references to the first and last node and
+offers an array-like interface for adding and removing items:
+
+* `push` (*insert value at back*);
+* `pop` (*remove value at back*);
+* `shift` (*remove value at front*).
+* `unshift` (*insert value at front*);
+
+To keep your implementation simple, the tests will not cover error
+conditions. Specifically: `pop` or `shift` will never be called on an
+empty list.
+
+If you want to know more about linked lists, check [Wikipedia](https://en.wikipedia.org/wiki/Linked_list).
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby linked_list_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride linked_list_test.rb
+
+
+## Source
+
+Classic computer science topic
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/linked-list/linked_list_test.rb
+++ b/exercises/linked-list/linked_list_test.rb
@@ -1,0 +1,70 @@
+require 'minitest/autorun'
+require_relative 'linked_list'
+
+class DequeTest < Minitest::Test
+  def test_push_pop
+    deque = Deque.new
+    deque.push(10)
+    deque.push(20)
+    assert_equal 20, deque.pop
+    assert_equal 10, deque.pop
+  end
+
+  def test_push_shift
+    skip
+    deque = Deque.new
+    deque.push(10)
+    deque.push(20)
+    assert_equal 10, deque.shift
+    assert_equal 20, deque.shift
+  end
+
+  def test_unshift_shift
+    skip
+    deque = Deque.new
+    deque.unshift(10)
+    deque.unshift(20)
+    assert_equal 20, deque.shift
+    assert_equal 10, deque.shift
+  end
+
+  def test_unshift_pop
+    skip
+    deque = Deque.new
+    deque.unshift(10)
+    deque.unshift(20)
+    assert_equal 10, deque.pop
+    assert_equal 20, deque.pop
+  end
+
+  def test_example
+    skip
+    deque = Deque.new
+    deque.push(10)
+    deque.push(20)
+    assert_equal 20, deque.pop
+    deque.push(30)
+    assert_equal 10, deque.shift
+    deque.unshift(40)
+    deque.push(50)
+    assert_equal 40, deque.shift
+    assert_equal 50, deque.pop
+    assert_equal 30, deque.shift
+  end
+
+  def test_pop_to_empty
+    deque = Deque.new
+    deque.push(10)
+    assert_equal 10, deque.pop
+    deque.push(20)
+    assert_equal 20, deque.shift
+  end
+
+  def test_shift_to_empty
+    deque = Deque.new
+    deque.unshift(10)
+    assert_equal 10, deque.shift
+    deque.unshift(20)
+    assert_equal 20, deque.pop
+  end
+end

--- a/exercises/list-ops/README.md
+++ b/exercises/list-ops/README.md
@@ -1,0 +1,33 @@
+# List Ops
+
+Implement basic list operations.
+
+In functional languages list operations like `length`, `map`, and
+`reduce` are very common. Implement a series of basic list operations,
+without using existing functions.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby list_ops_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride list_ops_test.rb
+
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/list-ops/list_ops_test.rb
+++ b/exercises/list-ops/list_ops_test.rb
@@ -1,0 +1,110 @@
+require 'minitest/autorun'
+require_relative 'list_ops'
+
+class ListOpsTest < Minitest::Test
+  def test_count_empty
+    assert_equal 0, ListOps.arrays([])
+  end
+
+  def test_count_normal
+    skip
+    assert_equal 5, ListOps.arrays(Array.new(5))
+  end
+
+  def test_count_gigantic
+    skip
+    assert_equal 1_000_000, ListOps.arrays(Array.new(1_000_000))
+  end
+
+  def test_reverse_empty
+    skip
+    assert_equal [], ListOps.reverser([])
+  end
+
+  def test_reverse_normal
+    skip
+    assert_equal [5, 4, 3, 2, 1], ListOps.reverser([1, 2, 3, 4, 5])
+  end
+
+  def test_reverse_gigantic
+    skip
+    expected = (1..1_000_000).to_a.reverse
+    assert_equal expected, ListOps.reverser((1..1_000_000).to_a)
+  end
+
+  def test_concat_empty
+    skip
+    assert_equal [], ListOps.concatter([], [])
+  end
+
+  def test_concat_normal
+    skip
+    assert_equal [12, 34, 56, 78], ListOps.concatter([12, 34], [56, 78])
+  end
+
+  def test_concat_gigantic
+    skip
+    input1 = (1..1_000_000).to_a
+    input2 = (1_000_001..2_000_000).to_a
+    assert_equal (1..2_000_000).to_a, ListOps.concatter(input1, input2)
+  end
+
+  def test_mapper_empty
+    skip
+    assert_equal [], ListOps.mapper([])
+  end
+
+  def test_mapper_normal
+    skip
+    assert_equal [2, 3, 4, 5, 6], ListOps.mapper([1, 2, 3, 4, 5]) { |n| n + 1 }
+  end
+
+  def test_mapper_gigantic
+    skip
+    result = ListOps.mapper((1..1_000_000).to_a) { |n| n + 1 }
+    assert_equal (2..1_000_001).to_a, result
+  end
+
+  def test_filterer_empty
+    skip
+    assert_equal [], ListOps.filterer([])
+  end
+
+  def test_filterer_normal
+    skip
+    result = ListOps.filterer([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], &:odd?)
+    assert_equal [1, 3, 5, 7, 9], result
+  end
+
+  def test_filterer_gigantic
+    skip
+    result = ListOps.filterer((1..10_000).to_a, &:even?)
+    assert_equal (1..10_000).to_a.select(&:even?), result
+  end
+
+  def test_sum_reducer_empty
+    skip
+    assert_equal 0, ListOps.sum_reducer([])
+  end
+
+  def test_sum_reducer_normal
+    skip
+    assert_equal 55, ListOps.sum_reducer([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+  end
+
+  def test_factorial_reducer_empty
+    skip
+    assert_equal 1, ListOps.factorial_reducer([])
+  end
+
+  def test_factorial_reducer_normal
+    skip
+    input = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    assert_equal 3_628_800, ListOps.factorial_reducer(input)
+  end
+
+  def test_bookkeeping
+    skip
+    assert_equal 2, BookKeeping::VERSION
+  end
+end

--- a/exercises/luhn/README.md
+++ b/exercises/luhn/README.md
@@ -1,0 +1,95 @@
+# Luhn
+
+Given a number determine whether or not it is valid per the Luhn formula.
+
+The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is
+a simple checksum formula used to validate a variety of identification
+numbers, such as credit card numbers and Canadian Social Insurance
+Numbers.
+
+The task is to check if a given string is valid.
+
+Validating a Number
+------
+
+Strings of length 1 or less are not valid. Spaces are allowed in the input,
+but they should be stripped before checking. All other non-digit characters
+are disallowed.
+
+## Example 1: valid credit card number
+
+```text
+4539 1488 0343 6467
+```
+
+The first step of the Luhn algorithm is to double every second digit,
+starting from the right. We will be doubling
+
+```text
+4_3_ 1_8_ 0_4_ 6_6_
+```
+
+If doubling the number results in a number greater than 9 then subtract 9
+from the product. The results of our doubling:
+
+```text
+8569 2478 0383 3437
+```
+
+Then sum all of the digits:
+
+```text
+8+5+6+9+2+4+7+8+0+3+8+3+3+4+3+7 = 80
+```
+
+If the sum is evenly divisible by 10, then the number is valid. This number is valid!
+
+## Example 2: invalid credit card number
+
+```text
+8273 1232 7352 0569
+```
+
+Double the second digits, starting from the right
+
+```text
+7253 2262 5312 0539
+```
+
+Sum the digits
+
+```text
+7+2+5+3+2+2+6+2+5+3+1+2+0+5+3+9 = 57
+```
+
+57 is not evenly divisible by 10, so this number is not valid.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby luhn_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride luhn_test.rb
+
+
+## Source
+
+The Luhn Algorithm on Wikipedia [http://en.wikipedia.org/wiki/Luhn_algorithm](http://en.wikipedia.org/wiki/Luhn_algorithm)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/luhn/luhn_test.rb
+++ b/exercises/luhn/luhn_test.rb
@@ -1,0 +1,92 @@
+require 'minitest/autorun'
+require_relative 'luhn'
+
+# Common test data version: 1.0.0 c826372
+class LuhnTest < Minitest::Test
+  def test_single_digit_strings_can_not_be_valid
+    # skip
+    refute Luhn.valid?("1")
+  end
+
+  def test_a_single_zero_is_invalid
+    skip
+    refute Luhn.valid?("0")
+  end
+
+  def test_a_simple_valid_sin_that_remains_valid_if_reversed
+    skip
+    assert Luhn.valid?("059")
+  end
+
+  def test_a_simple_valid_sin_that_becomes_invalid_if_reversed
+    skip
+    assert Luhn.valid?("59")
+  end
+
+  def test_a_valid_canadian_sin
+    skip
+    assert Luhn.valid?("055 444 285")
+  end
+
+  def test_invalid_canadian_sin
+    skip
+    refute Luhn.valid?("055 444 286")
+  end
+
+  def test_invalid_credit_card
+    skip
+    refute Luhn.valid?("8273 1232 7352 0569")
+  end
+
+  def test_valid_strings_with_a_non_digit_included_become_invalid
+    skip
+    refute Luhn.valid?("055a 444 285")
+  end
+
+  def test_valid_strings_with_punctuation_included_become_invalid
+    skip
+    refute Luhn.valid?("055-444-285")
+  end
+
+  def test_valid_strings_with_symbols_included_become_invalid
+    skip
+    refute Luhn.valid?("055£ 444$ 285")
+  end
+
+  def test_single_zero_with_space_is_invalid
+    skip
+    refute Luhn.valid?(" 0")
+  end
+
+  def test_more_than_a_single_zero_is_valid
+    skip
+    assert Luhn.valid?("0000 0")
+  end
+
+  def test_input_digit_9_is_correctly_converted_to_output_digit_9
+    skip
+    assert Luhn.valid?("091")
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/matrix/README.md
+++ b/exercises/matrix/README.md
@@ -1,0 +1,71 @@
+# Matrix
+
+Given a string representing a matrix of numbers, return the rows and columns of
+that matrix.
+
+So given a string with embedded newlines like:
+
+```text
+9 8 7
+5 3 2
+6 6 7
+```
+
+representing this matrix:
+
+```text
+    0  1  2
+  |---------
+0 | 9  8  7
+1 | 5  3  2
+2 | 6  6  7
+```
+
+your code should be able to spit out:
+
+- A list of the rows, reading each row left-to-right while moving
+  top-to-bottom across the rows,
+- A list of the columns, reading each column top-to-bottom while moving
+  from left-to-right.
+
+The rows for our example matrix:
+
+- 9, 8, 7
+- 5, 3, 2
+- 6, 6, 7
+
+And its columns:
+
+- 9, 5, 6
+- 8, 3, 6
+- 7, 2, 7
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby matrix_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride matrix_test.rb
+
+
+## Source
+
+Warmup to the `saddle-points` warmup. [http://jumpstartlab.com](http://jumpstartlab.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/matrix/matrix_test.rb
+++ b/exercises/matrix/matrix_test.rb
@@ -1,0 +1,39 @@
+require 'minitest/autorun'
+require_relative 'matrix'
+
+class MatrixTest < Minitest::Test
+  def test_extract_a_row
+    matrix = Matrix.new("1 2\n10 20")
+    assert_equal [1, 2], matrix.rows[0]
+  end
+
+  def test_extract_same_row_again
+    skip
+    matrix = Matrix.new("9 7\n8 6")
+    assert_equal [9, 7], matrix.rows[0]
+  end
+
+  def test_extract_other_row
+    skip
+    matrix = Matrix.new("9 8 7\n19 18 17")
+    assert_equal [19, 18, 17], matrix.rows[1]
+  end
+
+  def test_extract_other_row_again
+    skip
+    matrix = Matrix.new("1 4 9\n16 25 36")
+    assert_equal [16, 25, 36], matrix.rows[1]
+  end
+
+  def test_extract_a_column
+    skip
+    matrix = Matrix.new("1 2 3\n4 5 6\n7 8 9\n 8 7 6")
+    assert_equal [1, 4, 7, 8], matrix.columns[0]
+  end
+
+  def test_extract_another_column
+    skip
+    matrix = Matrix.new("89 1903 3\n18 3 1\n9 4 800")
+    assert_equal [1903, 3, 4], matrix.columns[1]
+  end
+end

--- a/exercises/meetup/README.md
+++ b/exercises/meetup/README.md
@@ -1,0 +1,57 @@
+# Meetup
+
+Calculate the date of meetups.
+
+Typically meetups happen on the same day of the week.  In this exercise, you
+will take a description of a meetup date, and return the actual meetup date.
+
+Examples of general descriptions are:
+
+- The first Monday of January 2017
+- The third Tuesday of January 2017
+- The wednesteenth of January 2017
+- The last Thursday of January 2017
+
+The descriptors you are expected to parse are:
+first, second, third, fourth, fifth, last, monteenth, tuesteenth, wednesteenth,
+thursteenth, friteenth, saturteenth, sunteenth
+
+Note that "monteenth", "tuesteenth", etc are all made up words. There was a
+meetup whose members realized that there are exactly 7 numbered days in a month
+that end in '-teenth'. Therefore, one is guaranteed that each day of the week
+(Monday, Tuesday, ...) will have exactly one date that is named with '-teenth'
+in every month.
+
+Given examples of a meetup dates, each containing a month, day, year, and
+descriptor calculate the date of the actual meetup.  For example, if given
+"The first Monday of January 2017", the correct meetup date is 2017/1/2.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby meetup_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride meetup_test.rb
+
+
+## Source
+
+Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month [https://twitter.com/copiousfreetime](https://twitter.com/copiousfreetime)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/meetup/meetup_test.rb
+++ b/exercises/meetup/meetup_test.rb
@@ -1,0 +1,597 @@
+require 'minitest/autorun'
+require_relative 'meetup'
+
+# Common test data version: 1.0.0 fe9630e
+class MeetupTest < Minitest::Test
+  def test_monteenth_of_may_2013
+    # skip
+    assert_equal Date.new(2013, 5, 13),
+      Meetup.new(5, 2013).day(:monday, :teenth)
+  end
+
+  def test_monteenth_of_august_2013
+    skip
+    assert_equal Date.new(2013, 8, 19),
+      Meetup.new(8, 2013).day(:monday, :teenth)
+  end
+
+  def test_monteenth_of_september_2013
+    skip
+    assert_equal Date.new(2013, 9, 16),
+      Meetup.new(9, 2013).day(:monday, :teenth)
+  end
+
+  def test_tuesteenth_of_march_2013
+    skip
+    assert_equal Date.new(2013, 3, 19),
+      Meetup.new(3, 2013).day(:tuesday, :teenth)
+  end
+
+  def test_tuesteenth_of_april_2013
+    skip
+    assert_equal Date.new(2013, 4, 16),
+      Meetup.new(4, 2013).day(:tuesday, :teenth)
+  end
+
+  def test_tuesteenth_of_august_2013
+    skip
+    assert_equal Date.new(2013, 8, 13),
+      Meetup.new(8, 2013).day(:tuesday, :teenth)
+  end
+
+  def test_wednesteenth_of_january_2013
+    skip
+    assert_equal Date.new(2013, 1, 16),
+      Meetup.new(1, 2013).day(:wednesday, :teenth)
+  end
+
+  def test_wednesteenth_of_february_2013
+    skip
+    assert_equal Date.new(2013, 2, 13),
+      Meetup.new(2, 2013).day(:wednesday, :teenth)
+  end
+
+  def test_wednesteenth_of_june_2013
+    skip
+    assert_equal Date.new(2013, 6, 19),
+      Meetup.new(6, 2013).day(:wednesday, :teenth)
+  end
+
+  def test_thursteenth_of_may_2013
+    skip
+    assert_equal Date.new(2013, 5, 16),
+      Meetup.new(5, 2013).day(:thursday, :teenth)
+  end
+
+  def test_thursteenth_of_june_2013
+    skip
+    assert_equal Date.new(2013, 6, 13),
+      Meetup.new(6, 2013).day(:thursday, :teenth)
+  end
+
+  def test_thursteenth_of_september_2013
+    skip
+    assert_equal Date.new(2013, 9, 19),
+      Meetup.new(9, 2013).day(:thursday, :teenth)
+  end
+
+  def test_friteenth_of_april_2013
+    skip
+    assert_equal Date.new(2013, 4, 19),
+      Meetup.new(4, 2013).day(:friday, :teenth)
+  end
+
+  def test_friteenth_of_august_2013
+    skip
+    assert_equal Date.new(2013, 8, 16),
+      Meetup.new(8, 2013).day(:friday, :teenth)
+  end
+
+  def test_friteenth_of_september_2013
+    skip
+    assert_equal Date.new(2013, 9, 13),
+      Meetup.new(9, 2013).day(:friday, :teenth)
+  end
+
+  def test_saturteenth_of_february_2013
+    skip
+    assert_equal Date.new(2013, 2, 16),
+      Meetup.new(2, 2013).day(:saturday, :teenth)
+  end
+
+  def test_saturteenth_of_april_2013
+    skip
+    assert_equal Date.new(2013, 4, 13),
+      Meetup.new(4, 2013).day(:saturday, :teenth)
+  end
+
+  def test_saturteenth_of_october_2013
+    skip
+    assert_equal Date.new(2013, 10, 19),
+      Meetup.new(10, 2013).day(:saturday, :teenth)
+  end
+
+  def test_sunteenth_of_may_2013
+    skip
+    assert_equal Date.new(2013, 5, 19),
+      Meetup.new(5, 2013).day(:sunday, :teenth)
+  end
+
+  def test_sunteenth_of_june_2013
+    skip
+    assert_equal Date.new(2013, 6, 16),
+      Meetup.new(6, 2013).day(:sunday, :teenth)
+  end
+
+  def test_sunteenth_of_october_2013
+    skip
+    assert_equal Date.new(2013, 10, 13),
+      Meetup.new(10, 2013).day(:sunday, :teenth)
+  end
+
+  def test_first_monday_of_march_2013
+    skip
+    assert_equal Date.new(2013, 3, 4),
+      Meetup.new(3, 2013).day(:monday, :first)
+  end
+
+  def test_first_monday_of_april_2013
+    skip
+    assert_equal Date.new(2013, 4, 1),
+      Meetup.new(4, 2013).day(:monday, :first)
+  end
+
+  def test_first_tuesday_of_may_2013
+    skip
+    assert_equal Date.new(2013, 5, 7),
+      Meetup.new(5, 2013).day(:tuesday, :first)
+  end
+
+  def test_first_tuesday_of_june_2013
+    skip
+    assert_equal Date.new(2013, 6, 4),
+      Meetup.new(6, 2013).day(:tuesday, :first)
+  end
+
+  def test_first_wednesday_of_july_2013
+    skip
+    assert_equal Date.new(2013, 7, 3),
+      Meetup.new(7, 2013).day(:wednesday, :first)
+  end
+
+  def test_first_wednesday_of_august_2013
+    skip
+    assert_equal Date.new(2013, 8, 7),
+      Meetup.new(8, 2013).day(:wednesday, :first)
+  end
+
+  def test_first_thursday_of_september_2013
+    skip
+    assert_equal Date.new(2013, 9, 5),
+      Meetup.new(9, 2013).day(:thursday, :first)
+  end
+
+  def test_first_thursday_of_october_2013
+    skip
+    assert_equal Date.new(2013, 10, 3),
+      Meetup.new(10, 2013).day(:thursday, :first)
+  end
+
+  def test_first_friday_of_november_2013
+    skip
+    assert_equal Date.new(2013, 11, 1),
+      Meetup.new(11, 2013).day(:friday, :first)
+  end
+
+  def test_first_friday_of_december_2013
+    skip
+    assert_equal Date.new(2013, 12, 6),
+      Meetup.new(12, 2013).day(:friday, :first)
+  end
+
+  def test_first_saturday_of_january_2013
+    skip
+    assert_equal Date.new(2013, 1, 5),
+      Meetup.new(1, 2013).day(:saturday, :first)
+  end
+
+  def test_first_saturday_of_february_2013
+    skip
+    assert_equal Date.new(2013, 2, 2),
+      Meetup.new(2, 2013).day(:saturday, :first)
+  end
+
+  def test_first_sunday_of_march_2013
+    skip
+    assert_equal Date.new(2013, 3, 3),
+      Meetup.new(3, 2013).day(:sunday, :first)
+  end
+
+  def test_first_sunday_of_april_2013
+    skip
+    assert_equal Date.new(2013, 4, 7),
+      Meetup.new(4, 2013).day(:sunday, :first)
+  end
+
+  def test_second_monday_of_march_2013
+    skip
+    assert_equal Date.new(2013, 3, 11),
+      Meetup.new(3, 2013).day(:monday, :second)
+  end
+
+  def test_second_monday_of_april_2013
+    skip
+    assert_equal Date.new(2013, 4, 8),
+      Meetup.new(4, 2013).day(:monday, :second)
+  end
+
+  def test_second_tuesday_of_may_2013
+    skip
+    assert_equal Date.new(2013, 5, 14),
+      Meetup.new(5, 2013).day(:tuesday, :second)
+  end
+
+  def test_second_tuesday_of_june_2013
+    skip
+    assert_equal Date.new(2013, 6, 11),
+      Meetup.new(6, 2013).day(:tuesday, :second)
+  end
+
+  def test_second_wednesday_of_july_2013
+    skip
+    assert_equal Date.new(2013, 7, 10),
+      Meetup.new(7, 2013).day(:wednesday, :second)
+  end
+
+  def test_second_wednesday_of_august_2013
+    skip
+    assert_equal Date.new(2013, 8, 14),
+      Meetup.new(8, 2013).day(:wednesday, :second)
+  end
+
+  def test_second_thursday_of_september_2013
+    skip
+    assert_equal Date.new(2013, 9, 12),
+      Meetup.new(9, 2013).day(:thursday, :second)
+  end
+
+  def test_second_thursday_of_october_2013
+    skip
+    assert_equal Date.new(2013, 10, 10),
+      Meetup.new(10, 2013).day(:thursday, :second)
+  end
+
+  def test_second_friday_of_november_2013
+    skip
+    assert_equal Date.new(2013, 11, 8),
+      Meetup.new(11, 2013).day(:friday, :second)
+  end
+
+  def test_second_friday_of_december_2013
+    skip
+    assert_equal Date.new(2013, 12, 13),
+      Meetup.new(12, 2013).day(:friday, :second)
+  end
+
+  def test_second_saturday_of_january_2013
+    skip
+    assert_equal Date.new(2013, 1, 12),
+      Meetup.new(1, 2013).day(:saturday, :second)
+  end
+
+  def test_second_saturday_of_february_2013
+    skip
+    assert_equal Date.new(2013, 2, 9),
+      Meetup.new(2, 2013).day(:saturday, :second)
+  end
+
+  def test_second_sunday_of_march_2013
+    skip
+    assert_equal Date.new(2013, 3, 10),
+      Meetup.new(3, 2013).day(:sunday, :second)
+  end
+
+  def test_second_sunday_of_april_2013
+    skip
+    assert_equal Date.new(2013, 4, 14),
+      Meetup.new(4, 2013).day(:sunday, :second)
+  end
+
+  def test_third_monday_of_march_2013
+    skip
+    assert_equal Date.new(2013, 3, 18),
+      Meetup.new(3, 2013).day(:monday, :third)
+  end
+
+  def test_third_monday_of_april_2013
+    skip
+    assert_equal Date.new(2013, 4, 15),
+      Meetup.new(4, 2013).day(:monday, :third)
+  end
+
+  def test_third_tuesday_of_may_2013
+    skip
+    assert_equal Date.new(2013, 5, 21),
+      Meetup.new(5, 2013).day(:tuesday, :third)
+  end
+
+  def test_third_tuesday_of_june_2013
+    skip
+    assert_equal Date.new(2013, 6, 18),
+      Meetup.new(6, 2013).day(:tuesday, :third)
+  end
+
+  def test_third_wednesday_of_july_2013
+    skip
+    assert_equal Date.new(2013, 7, 17),
+      Meetup.new(7, 2013).day(:wednesday, :third)
+  end
+
+  def test_third_wednesday_of_august_2013
+    skip
+    assert_equal Date.new(2013, 8, 21),
+      Meetup.new(8, 2013).day(:wednesday, :third)
+  end
+
+  def test_third_thursday_of_september_2013
+    skip
+    assert_equal Date.new(2013, 9, 19),
+      Meetup.new(9, 2013).day(:thursday, :third)
+  end
+
+  def test_third_thursday_of_october_2013
+    skip
+    assert_equal Date.new(2013, 10, 17),
+      Meetup.new(10, 2013).day(:thursday, :third)
+  end
+
+  def test_third_friday_of_november_2013
+    skip
+    assert_equal Date.new(2013, 11, 15),
+      Meetup.new(11, 2013).day(:friday, :third)
+  end
+
+  def test_third_friday_of_december_2013
+    skip
+    assert_equal Date.new(2013, 12, 20),
+      Meetup.new(12, 2013).day(:friday, :third)
+  end
+
+  def test_third_saturday_of_january_2013
+    skip
+    assert_equal Date.new(2013, 1, 19),
+      Meetup.new(1, 2013).day(:saturday, :third)
+  end
+
+  def test_third_saturday_of_february_2013
+    skip
+    assert_equal Date.new(2013, 2, 16),
+      Meetup.new(2, 2013).day(:saturday, :third)
+  end
+
+  def test_third_sunday_of_march_2013
+    skip
+    assert_equal Date.new(2013, 3, 17),
+      Meetup.new(3, 2013).day(:sunday, :third)
+  end
+
+  def test_third_sunday_of_april_2013
+    skip
+    assert_equal Date.new(2013, 4, 21),
+      Meetup.new(4, 2013).day(:sunday, :third)
+  end
+
+  def test_fourth_monday_of_march_2013
+    skip
+    assert_equal Date.new(2013, 3, 25),
+      Meetup.new(3, 2013).day(:monday, :fourth)
+  end
+
+  def test_fourth_monday_of_april_2013
+    skip
+    assert_equal Date.new(2013, 4, 22),
+      Meetup.new(4, 2013).day(:monday, :fourth)
+  end
+
+  def test_fourth_tuesday_of_may_2013
+    skip
+    assert_equal Date.new(2013, 5, 28),
+      Meetup.new(5, 2013).day(:tuesday, :fourth)
+  end
+
+  def test_fourth_tuesday_of_june_2013
+    skip
+    assert_equal Date.new(2013, 6, 25),
+      Meetup.new(6, 2013).day(:tuesday, :fourth)
+  end
+
+  def test_fourth_wednesday_of_july_2013
+    skip
+    assert_equal Date.new(2013, 7, 24),
+      Meetup.new(7, 2013).day(:wednesday, :fourth)
+  end
+
+  def test_fourth_wednesday_of_august_2013
+    skip
+    assert_equal Date.new(2013, 8, 28),
+      Meetup.new(8, 2013).day(:wednesday, :fourth)
+  end
+
+  def test_fourth_thursday_of_september_2013
+    skip
+    assert_equal Date.new(2013, 9, 26),
+      Meetup.new(9, 2013).day(:thursday, :fourth)
+  end
+
+  def test_fourth_thursday_of_october_2013
+    skip
+    assert_equal Date.new(2013, 10, 24),
+      Meetup.new(10, 2013).day(:thursday, :fourth)
+  end
+
+  def test_fourth_friday_of_november_2013
+    skip
+    assert_equal Date.new(2013, 11, 22),
+      Meetup.new(11, 2013).day(:friday, :fourth)
+  end
+
+  def test_fourth_friday_of_december_2013
+    skip
+    assert_equal Date.new(2013, 12, 27),
+      Meetup.new(12, 2013).day(:friday, :fourth)
+  end
+
+  def test_fourth_saturday_of_january_2013
+    skip
+    assert_equal Date.new(2013, 1, 26),
+      Meetup.new(1, 2013).day(:saturday, :fourth)
+  end
+
+  def test_fourth_saturday_of_february_2013
+    skip
+    assert_equal Date.new(2013, 2, 23),
+      Meetup.new(2, 2013).day(:saturday, :fourth)
+  end
+
+  def test_fourth_sunday_of_march_2013
+    skip
+    assert_equal Date.new(2013, 3, 24),
+      Meetup.new(3, 2013).day(:sunday, :fourth)
+  end
+
+  def test_fourth_sunday_of_april_2013
+    skip
+    assert_equal Date.new(2013, 4, 28),
+      Meetup.new(4, 2013).day(:sunday, :fourth)
+  end
+
+  def test_last_monday_of_march_2013
+    skip
+    assert_equal Date.new(2013, 3, 25),
+      Meetup.new(3, 2013).day(:monday, :last)
+  end
+
+  def test_last_monday_of_april_2013
+    skip
+    assert_equal Date.new(2013, 4, 29),
+      Meetup.new(4, 2013).day(:monday, :last)
+  end
+
+  def test_last_tuesday_of_may_2013
+    skip
+    assert_equal Date.new(2013, 5, 28),
+      Meetup.new(5, 2013).day(:tuesday, :last)
+  end
+
+  def test_last_tuesday_of_june_2013
+    skip
+    assert_equal Date.new(2013, 6, 25),
+      Meetup.new(6, 2013).day(:tuesday, :last)
+  end
+
+  def test_last_wednesday_of_july_2013
+    skip
+    assert_equal Date.new(2013, 7, 31),
+      Meetup.new(7, 2013).day(:wednesday, :last)
+  end
+
+  def test_last_wednesday_of_august_2013
+    skip
+    assert_equal Date.new(2013, 8, 28),
+      Meetup.new(8, 2013).day(:wednesday, :last)
+  end
+
+  def test_last_thursday_of_september_2013
+    skip
+    assert_equal Date.new(2013, 9, 26),
+      Meetup.new(9, 2013).day(:thursday, :last)
+  end
+
+  def test_last_thursday_of_october_2013
+    skip
+    assert_equal Date.new(2013, 10, 31),
+      Meetup.new(10, 2013).day(:thursday, :last)
+  end
+
+  def test_last_friday_of_november_2013
+    skip
+    assert_equal Date.new(2013, 11, 29),
+      Meetup.new(11, 2013).day(:friday, :last)
+  end
+
+  def test_last_friday_of_december_2013
+    skip
+    assert_equal Date.new(2013, 12, 27),
+      Meetup.new(12, 2013).day(:friday, :last)
+  end
+
+  def test_last_saturday_of_january_2013
+    skip
+    assert_equal Date.new(2013, 1, 26),
+      Meetup.new(1, 2013).day(:saturday, :last)
+  end
+
+  def test_last_saturday_of_february_2013
+    skip
+    assert_equal Date.new(2013, 2, 23),
+      Meetup.new(2, 2013).day(:saturday, :last)
+  end
+
+  def test_last_sunday_of_march_2013
+    skip
+    assert_equal Date.new(2013, 3, 31),
+      Meetup.new(3, 2013).day(:sunday, :last)
+  end
+
+  def test_last_sunday_of_april_2013
+    skip
+    assert_equal Date.new(2013, 4, 28),
+      Meetup.new(4, 2013).day(:sunday, :last)
+  end
+
+  def test_last_wednesday_of_february_2012
+    skip
+    assert_equal Date.new(2012, 2, 29),
+      Meetup.new(2, 2012).day(:wednesday, :last)
+  end
+
+  def test_last_wednesday_of_december_2014
+    skip
+    assert_equal Date.new(2014, 12, 31),
+      Meetup.new(12, 2014).day(:wednesday, :last)
+  end
+
+  def test_last_sunday_of_february_2015
+    skip
+    assert_equal Date.new(2015, 2, 22),
+      Meetup.new(2, 2015).day(:sunday, :last)
+  end
+
+  def test_first_friday_of_december_2012
+    skip
+    assert_equal Date.new(2012, 12, 7),
+      Meetup.new(12, 2012).day(:friday, :first)
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/minesweeper/README.md
+++ b/exercises/minesweeper/README.md
@@ -1,0 +1,53 @@
+# Minesweeper
+
+Add the numbers to a minesweeper board.
+
+Minesweeper is a popular game where the user has to find the mines using
+numeric hints that indicate how many mines are directly adjacent
+(horizontally, vertically, diagonally) to a square.
+
+In this exercise you have to create some code that counts the number of
+mines adjacent to a square and transforms boards like this (where `*`
+indicates a mine):
+
+    +-----+
+    | * * |
+    |  *  |
+    |  *  |
+    |     |
+    +-----+
+
+into this:
+
+    +-----+
+    |1*3*1|
+    |13*31|
+    | 2*2 |
+    | 111 |
+    +-----+
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby minesweeper_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride minesweeper_test.rb
+
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/minesweeper/minesweeper_test.rb
+++ b/exercises/minesweeper/minesweeper_test.rb
@@ -1,0 +1,96 @@
+require 'minitest/autorun'
+require_relative 'minesweeper'
+
+class MinesweeperTest < Minitest::Test
+  def test_transform1
+    inp = ['+------+', '| *  * |', '|  *   |', '|    * |', '|   * *|',
+           '| *  * |', '|      |', '+------+']
+    out = ['+------+', '|1*22*1|', '|12*322|', '| 123*2|', '|112*4*|',
+           '|1*22*2|', '|111111|', '+------+']
+    assert_equal out, Board.transform(inp)
+  end
+
+  def test_transform2
+    skip
+    inp = ['+-----+', '| * * |', '|     |', '|   * |', '|  * *|',
+           '| * * |', '+-----+']
+    out = ['+-----+', '|1*2*1|', '|11322|', '| 12*2|', '|12*4*|',
+           '|1*3*2|', '+-----+']
+    assert_equal out, Board.transform(inp)
+  end
+
+  def test_transform3
+    skip
+    inp = ['+-----+', '| * * |', '+-----+']
+    out = ['+-----+', '|1*2*1|', '+-----+']
+    assert_equal out, Board.transform(inp)
+  end
+
+  def test_transform4
+    skip
+    inp = ['+-+', '|*|', '| |', '|*|', '| |', '| |', '+-+']
+    out = ['+-+', '|*|', '|2|', '|*|', '|1|', '| |', '+-+']
+    assert_equal out, Board.transform(inp)
+  end
+
+  def test_transform5
+    skip
+    inp = ['+-+', '|*|', '+-+']
+    out = ['+-+', '|*|', '+-+']
+    assert_equal out, Board.transform(inp)
+  end
+
+  def test_transform6
+    skip
+    inp = ['+--+', '|**|', '|**|', '+--+']
+    out = ['+--+', '|**|', '|**|', '+--+']
+    assert_equal out, Board.transform(inp)
+  end
+
+  def test_transform7
+    skip
+    inp = ['+--+', '|**|', '|**|', '+--+']
+    out = ['+--+', '|**|', '|**|', '+--+']
+    assert_equal out, Board.transform(inp)
+  end
+
+  def test_transform8
+    skip
+    inp = ['+---+', '|***|', '|* *|', '|***|', '+---+']
+    out = ['+---+', '|***|', '|*8*|', '|***|', '+---+']
+    assert_equal out, Board.transform(inp)
+  end
+
+  def test_transform9
+    skip
+    inp = ['+-----+', '|     |', '|   * |', '|     |', '|     |',
+           '| *   |', '+-----+']
+    out = ['+-----+', '|  111|', '|  1*1|', '|  111|', '|111  |',
+           '|1*1  |', '+-----+']
+    assert_equal out, Board.transform(inp)
+  end
+
+  def test_different_len
+    skip
+    inp = ['+-+', '| |', '|*  |', '|  |', '+-+']
+    assert_raises(ArgumentError) do
+      Board.transform(inp)
+    end
+  end
+
+  def test_faulty_border
+    skip
+    inp = ['+-----+', '*   * |', '+-- --+']
+    assert_raises(ArgumentError) do
+      Board.transform(inp)
+    end
+  end
+
+  def test_invalid_char
+    skip
+    inp = ['+-----+', '|X  * |', '+-----+']
+    assert_raises(ArgumentError) do
+      Board.transform(inp)
+    end
+  end
+end

--- a/exercises/nth-prime/README.md
+++ b/exercises/nth-prime/README.md
@@ -1,0 +1,39 @@
+# Nth Prime
+
+Given a number n, determine what the nth prime is.
+
+By listing the first six prime numbers: 2, 3, 5, 7, 11, and 13, we can see that
+the 6th prime is 13.
+
+If your language provides methods in the standard library to deal with prime
+numbers, pretend they don't exist and implement them yourself.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby nth_prime_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride nth_prime_test.rb
+
+
+## Source
+
+A variation on Problem 7 at Project Euler [http://projecteuler.net/problem=7](http://projecteuler.net/problem=7)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/nth-prime/nth_prime_test.rb
+++ b/exercises/nth-prime/nth_prime_test.rb
@@ -1,0 +1,52 @@
+require 'minitest/autorun'
+require_relative 'nth_prime'
+
+# Common test data version: 1.0.0 016d65b
+class NthPrimeTest < Minitest::Test
+  def test_first_prime
+    # skip
+    assert_equal 2, Prime.nth(1)
+  end
+
+  def test_second_prime
+    skip
+    assert_equal 3, Prime.nth(2)
+  end
+
+  def test_sixth_prime
+    skip
+    assert_equal 13, Prime.nth(6)
+  end
+
+  def test_big_prime
+    skip
+    assert_equal 104743, Prime.nth(10001)
+  end
+
+  def test_there_is_no_zeroth_prime
+    skip
+    assert_raises(ArgumentError) { Prime.nth(0) }
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -1,0 +1,43 @@
+# Nucleotide Count
+
+Given a single stranded DNA string, compute how many times each nucleotide occurs in the string.
+
+The genetic language of every living thing on the planet is DNA.
+DNA is a large molecule that is built from an extremely long sequence of individual elements called nucleotides.
+4 types exist in DNA and these differ only slightly and can be represented as the following symbols: 'A' for adenine, 'C' for cytosine, 'G' for guanine, and 'T' thymine.
+
+Here is an analogy:
+- twigs are to birds nests as
+- nucleotides are to DNA as
+- legos are to lego houses as
+- words are to sentences as...
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby nucleotide_count_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride nucleotide_count_test.rb
+
+
+## Source
+
+The Calculating DNA Nucleotides_problem at Rosalind [http://rosalind.info/problems/dna/](http://rosalind.info/problems/dna/)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/nucleotide-count/nucleotide_count_test.rb
+++ b/exercises/nucleotide-count/nucleotide_count_test.rb
@@ -1,0 +1,53 @@
+require 'minitest/autorun'
+require_relative 'nucleotide_count'
+
+class NucleotideTest < Minitest::Test
+  def test_empty_dna_strand_has_no_adenosine
+    assert_equal 0, Nucleotide.from_dna('').count('A')
+  end
+
+  def test_repetitive_cytidine_gets_counted
+    skip
+    assert_equal 5, Nucleotide.from_dna('CCCCC').count('C')
+  end
+
+  def test_counts_only_thymidine
+    skip
+    assert_equal 1, Nucleotide.from_dna('GGGGGTAACCCGG').count('T')
+  end
+
+  def test_counts_a_nucleotide_only_once
+    skip
+    dna = Nucleotide.from_dna('CGATTGGG')
+    dna.count('T')
+    dna.count('T')
+    assert_equal 2, dna.count('T')
+  end
+
+  def test_empty_dna_strand_has_no_nucleotides
+    skip
+    expected = { 'A' => 0, 'T' => 0, 'C' => 0, 'G' => 0 }
+    assert_equal expected, Nucleotide.from_dna('').histogram
+  end
+
+  def test_repetitive_sequence_has_only_guanosine
+    skip
+    expected = { 'A' => 0, 'T' => 0, 'C' => 0, 'G' => 8 }
+    assert_equal expected, Nucleotide.from_dna('GGGGGGGG').histogram
+  end
+
+  def test_counts_all_nucleotides
+    skip
+    s = 'AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC'
+    dna = Nucleotide.from_dna(s)
+    expected = { 'A' => 20, 'T' => 21, 'G' => 17, 'C' => 12 }
+    assert_equal expected, dna.histogram
+  end
+
+  def test_validates_dna
+    skip
+    assert_raises ArgumentError do
+      Nucleotide.from_dna('JOHNNYAPPLESEED')
+    end
+  end
+end

--- a/exercises/ocr-numbers/README.md
+++ b/exercises/ocr-numbers/README.md
@@ -1,0 +1,109 @@
+# OCR Numbers
+
+Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is
+represented, or whether it is garbled.
+
+# Step One
+
+To begin with, convert a simple binary font to a string containing 0 or 1.
+
+The binary font uses pipes and underscores, four rows high and three columns wide.
+
+```text
+     _   #
+    | |  # zero.
+    |_|  #
+         # the fourth row is always blank
+```
+
+Is converted to "0"
+
+```text
+         #
+      |  # one.
+      |  #
+         # (blank fourth row)
+```
+
+Is converted to "1"
+
+If the input is the correct size, but not recognizable, your program should return '?'
+
+If the input is the incorrect size, your program should return an error.
+
+# Step Two
+
+Update your program to recognize multi-character binary strings, replacing garbled numbers with ?
+
+# Step Three
+
+Update your program to recognize all numbers 0 through 9, both individually and as part of a larger string.
+
+```text
+ _ 
+ _|
+|_ 
+   
+```
+
+Is converted to "2"
+
+```text
+      _  _     _  _  _  _  _  _  #
+    | _| _||_||_ |_   ||_||_|| | # decimal numbers.
+    ||_  _|  | _||_|  ||_| _||_| #
+                                 # fourth line is always blank
+```
+
+Is converted to "1234567890"
+
+# Step Four
+
+Update your program to handle multiple numbers, one per line. When converting several lines, join the lines with commas.
+
+```text
+    _  _ 
+  | _| _|
+  ||_  _|
+         
+    _  _ 
+|_||_ |_ 
+  | _||_|
+         
+ _  _  _ 
+  ||_||_|
+  ||_| _|
+         
+```
+
+Is converted to "123,456,789"
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby ocr_numbers_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride ocr_numbers_test.rb
+
+
+## Source
+
+Inspired by the Bank OCR kata [http://codingdojo.org/cgi-bin/wiki.pl?KataBankOCR](http://codingdojo.org/cgi-bin/wiki.pl?KataBankOCR)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/ocr-numbers/ocr_numbers_test.rb
+++ b/exercises/ocr-numbers/ocr_numbers_test.rb
@@ -1,0 +1,112 @@
+require 'minitest/autorun'
+require_relative 'ocr_numbers'
+
+# Common test data version: 1.0.0 80782b6
+class OcrNumbersTest < Minitest::Test
+  def test_recognizes_0
+    # skip
+    assert_equal "0", OcrNumbers.convert(" _ \n| |\n|_|\n   ")
+  end
+
+  def test_recognizes_1
+    skip
+    assert_equal "1", OcrNumbers.convert("   \n  |\n  |\n   ")
+  end
+
+  def test_unreadable_but_correctly_sized_inputs_return_?
+    skip
+    assert_equal "?", OcrNumbers.convert("   \n  _\n  |\n   ")
+  end
+
+  def test_input_with_a_number_of_lines_that_is_not_a_multiple_of_four_raises_an_error
+    skip
+    assert_raises(ArgumentError) { OcrNumbers.convert(" _ \n| |\n   ") }
+  end
+
+  def test_input_with_a_number_of_columns_that_is_not_a_multiple_of_three_raises_an_error
+    skip
+    assert_raises(ArgumentError) { OcrNumbers.convert("    \n   |\n   |\n    ") }
+  end
+
+  def test_recognizes_110101100
+    skip
+    assert_equal "110101100", OcrNumbers.convert("       _     _        _  _ \n  |  || |  || |  |  || || |\n  |  ||_|  ||_|  |  ||_||_|\n                           ")
+  end
+
+  def test_garbled_numbers_in_a_string_are_replaced_with_?
+    skip
+    assert_equal "11?10?1?0", OcrNumbers.convert("       _     _           _ \n  |  || |  || |     || || |\n  |  | _|  ||_|  |  ||_||_|\n                           ")
+  end
+
+  def test_recognizes_2
+    skip
+    assert_equal "2", OcrNumbers.convert(" _ \n _|\n|_ \n   ")
+  end
+
+  def test_recognizes_3
+    skip
+    assert_equal "3", OcrNumbers.convert(" _ \n _|\n _|\n   ")
+  end
+
+  def test_recognizes_4
+    skip
+    assert_equal "4", OcrNumbers.convert("   \n|_|\n  |\n   ")
+  end
+
+  def test_recognizes_5
+    skip
+    assert_equal "5", OcrNumbers.convert(" _ \n|_ \n _|\n   ")
+  end
+
+  def test_recognizes_6
+    skip
+    assert_equal "6", OcrNumbers.convert(" _ \n|_ \n|_|\n   ")
+  end
+
+  def test_recognizes_7
+    skip
+    assert_equal "7", OcrNumbers.convert(" _ \n  |\n  |\n   ")
+  end
+
+  def test_recognizes_8
+    skip
+    assert_equal "8", OcrNumbers.convert(" _ \n|_|\n|_|\n   ")
+  end
+
+  def test_recognizes_9
+    skip
+    assert_equal "9", OcrNumbers.convert(" _ \n|_|\n _|\n   ")
+  end
+
+  def test_recognizes_string_of_decimal_numbers
+    skip
+    assert_equal "1234567890", OcrNumbers.convert("    _  _     _  _  _  _  _  _ \n  | _| _||_||_ |_   ||_||_|| |\n  ||_  _|  | _||_|  ||_| _||_|\n                              ")
+  end
+
+  def test_numbers_separated_by_empty_lines_are_recognized_lines_are_joined_by_commas
+    skip
+    assert_equal "123,456,789", OcrNumbers.convert("    _  _ \n  | _| _|\n  ||_  _|\n         \n    _  _ \n|_||_ |_ \n  | _||_|\n         \n _  _  _ \n  ||_||_|\n  ||_| _|\n         ")
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/octal/README.md
+++ b/exercises/octal/README.md
@@ -1,0 +1,77 @@
+# Octal
+
+Convert an octal number, represented as a string (e.g. '1735263'), to its
+decimal equivalent using first principles (i.e. no, you may not use built-in or
+external libraries to accomplish the conversion).
+
+Implement octal to decimal conversion.  Given an octal input
+string, your program should produce a decimal output.
+
+## Note
+
+- Implement the conversion yourself.
+  Do not use something else to perform the conversion for you.
+- Treat invalid input as octal 0.
+
+## About Octal (Base-8)
+
+Decimal is a base-10 system.
+
+A number 233 in base 10 notation can be understood
+as a linear combination of powers of 10:
+
+- The rightmost digit gets multiplied by 10^0 = 1
+- The next number gets multiplied by 10^1 = 10
+- ...
+- The *n*th number gets multiplied by 10^*(n-1)*.
+- All these values are summed.
+
+So:
+
+```text
+   233 # decimal
+ = 2*10^2 + 3*10^1 + 3*10^0
+ = 2*100  + 3*10   + 3*1
+```
+
+Octal is similar, but uses powers of 8 rather than powers of 10.
+
+So:
+
+```text
+   233 # octal
+ = 2*8^2 + 3*8^1 + 3*8^0
+ = 2*64  + 3*8   + 3*1
+ = 128   + 24    + 3
+ = 155
+```
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby octal_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride octal_test.rb
+
+
+## Source
+
+All of Computer Science [http://www.wolframalpha.com/input/?i=base+8](http://www.wolframalpha.com/input/?i=base+8)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/octal/octal_test.rb
+++ b/exercises/octal/octal_test.rb
@@ -1,0 +1,73 @@
+require 'minitest/autorun'
+require_relative 'octal'
+
+class OctalTest < Minitest::Test
+  def test_octal_1_is_decimal_1
+    assert_equal 1, Octal.new('1').to_decimal
+  end
+
+  def test_octal_10_is_decimal_8
+    skip
+    assert_equal 8, Octal.new('10').to_decimal
+  end
+
+  def test_octal_17_is_decimal_15
+    skip
+    assert_equal 15, Octal.new('17').to_decimal
+  end
+
+  def test_octal_11_is_decimal_9
+    skip
+    assert_equal 9, Octal.new('11').to_decimal
+  end
+
+  def test_octal_130_is_decimal_88
+    skip
+    assert_equal 88, Octal.new('130').to_decimal
+  end
+
+  def test_octal_2047_is_decimal_1063
+    skip
+    assert_equal 1063, Octal.new('2047').to_decimal
+  end
+
+  def test_octal_7777_is_decimal_4095
+    skip
+    assert_equal 4095, Octal.new('7777').to_decimal
+  end
+
+  def test_octal_1234567_is_decimal_342391
+    skip
+    assert_equal 342_391, Octal.new('1234567').to_decimal
+  end
+
+  def test_invalid_octal_is_decimal_0
+    skip
+    assert_equal 0, Octal.new('carrot').to_decimal
+  end
+
+  def test_8_is_seen_as_invalid_and_returns_0
+    skip
+    assert_equal 0, Octal.new('8').to_decimal
+  end
+
+  def test_9_is_seen_as_invalid_and_returns_0
+    skip
+    assert_equal 0, Octal.new('9').to_decimal
+  end
+
+  def test_6789_is_seen_as_invalid_and_returns_0
+    skip
+    assert_equal 0, Octal.new('6789').to_decimal
+  end
+
+  def test_abc1z_is_seen_as_invalid_and_returns_0
+    skip
+    assert_equal 0, Octal.new('abc1z').to_decimal
+  end
+
+  def test_valid_octal_formatted_string_011_is_decimal_9
+    skip
+    assert_equal 9, Octal.new('011').to_decimal
+  end
+end

--- a/exercises/palindrome-products/README.md
+++ b/exercises/palindrome-products/README.md
@@ -1,0 +1,63 @@
+# Palindrome Products
+
+Detect palindrome products in a given range.
+
+A palindromic number is a number that remains the same when its digits are
+reversed. For example, `121` is a palindromic number but `112` is not.
+
+Given a range of numbers, find the largest and smallest palindromes which
+are products of numbers within that range.
+
+Your solution should return the largest and smallest palindromes, along with the
+factors of each within the range. If the largest or smallest palindrome has more
+than one pair of factors within the range, then return all the pairs.
+
+## Example 1
+
+Given the range `[1, 9]` (both inclusive)...
+
+And given the list of all possible products within this range:
+`[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16, 18, 15, 21, 24, 27, 20, 28, 32, 36, 25, 30, 35, 40, 45, 42, 48, 54, 49, 56, 63, 64, 72, 81]`
+
+The palindrome products are all single digit numbers (in this case):
+`[1, 2, 3, 4, 5, 6, 7, 8, 9]`
+
+The smallest palindrome product is `1`. Its factors are `(1, 1)`.
+The largest palindrome product is `9`. Its factors are `(1, 9)` and `(3, 3)`.
+
+## Example 2
+
+Given the range `[10, 99]` (both inclusive)...
+
+The smallest palindrome product is `121`. Its factors are `(11, 11)`.
+The largest palindrome product is `9009`. Its factors are `(91, 99)`.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby palindrome_products_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride palindrome_products_test.rb
+
+
+## Source
+
+Problem 4 at Project Euler [http://projecteuler.net/problem=4](http://projecteuler.net/problem=4)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/palindrome-products/palindrome_products_test.rb
+++ b/exercises/palindrome-products/palindrome_products_test.rb
@@ -1,0 +1,48 @@
+require 'minitest/autorun'
+require_relative 'palindrome_products'
+
+class PalindromesTest < Minitest::Test
+  def test_largest_palindrome_from_single_digit_factors
+    palindromes = Palindromes.new(max_factor: 9)
+    palindromes.generate
+    largest = palindromes.largest
+    assert_equal 9, largest.value
+    assert_includes [[[3, 3], [1, 9]], [[1, 9], [3, 3]]], largest.factors
+  end
+
+  def test_largest_palindrome_from_double_digit_factors
+    skip
+    palindromes = Palindromes.new(max_factor: 99, min_factor: 10)
+    palindromes.generate
+    largest = palindromes.largest
+    assert_equal 9009, largest.value
+    assert_equal [[91, 99]], largest.factors
+  end
+
+  def test_smallest_palindrome_from_double_digit_factors
+    skip
+    palindromes = Palindromes.new(max_factor: 99, min_factor: 10)
+    palindromes.generate
+    smallest = palindromes.smallest
+    assert_equal 121, smallest.value
+    assert_equal [[11, 11]], smallest.factors
+  end
+
+  def test_largest_palindrome_from_triple_digit_factors
+    skip
+    palindromes = Palindromes.new(max_factor: 999, min_factor: 100)
+    palindromes.generate
+    largest = palindromes.largest
+    assert_equal 906_609, largest.value
+    assert_equal [[913, 993]], largest.factors
+  end
+
+  def test_smallest_palindrome_from_triple_digit_factors
+    skip
+    palindromes = Palindromes.new(max_factor: 999, min_factor: 100)
+    palindromes.generate
+    smallest = palindromes.smallest
+    assert_equal 10_201, smallest.value
+    assert_equal [[101, 101]], smallest.factors
+  end
+end

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -1,0 +1,39 @@
+# Pangram
+
+Determine if a sentence is a pangram. A pangram (Greek: παν γράμμα, pan gramma,
+"every letter") is a sentence using every letter of the alphabet at least once.
+The best known English pangram is:
+> The quick brown fox jumps over the lazy dog.
+
+The alphabet used consists of ASCII letters `a` to `z`, inclusive, and is case
+insensitive. Input will not contain non-ASCII symbols.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby pangram_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride pangram_test.rb
+
+
+## Source
+
+Wikipedia [https://en.wikipedia.org/wiki/Pangram](https://en.wikipedia.org/wiki/Pangram)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/pangram/pangram_test.rb
+++ b/exercises/pangram/pangram_test.rb
@@ -1,0 +1,97 @@
+require 'minitest/autorun'
+require_relative 'pangram'
+
+# Common test data version: 1.3.0 d79e13e
+class PangramTest < Minitest::Test
+  def test_sentence_empty
+    # skip
+    phrase = ''
+    result = Pangram.pangram?(phrase)
+    refute result, "Expected false, got: #{result.inspect}. #{phrase.inspect} is NOT a pangram"
+  end
+
+  def test_recognizes_a_perfect_lower_case_pangram
+    skip
+    phrase = 'abcdefghijklmnopqrstuvwxyz'
+    result = Pangram.pangram?(phrase)
+    assert result, "Expected true, got: #{result.inspect}. #{phrase.inspect} IS a pangram"
+  end
+
+  def test_pangram_with_only_lower_case
+    skip
+    phrase = 'the quick brown fox jumps over the lazy dog'
+    result = Pangram.pangram?(phrase)
+    assert result, "Expected true, got: #{result.inspect}. #{phrase.inspect} IS a pangram"
+  end
+
+  def test_missing_character_x
+    skip
+    phrase = 'a quick movement of the enemy will jeopardize five gunboats'
+    result = Pangram.pangram?(phrase)
+    refute result, "Expected false, got: #{result.inspect}. #{phrase.inspect} is NOT a pangram"
+  end
+
+  def test_another_missing_character_eg_h
+    skip
+    phrase = 'five boxing wizards jump quickly at it'
+    result = Pangram.pangram?(phrase)
+    refute result, "Expected false, got: #{result.inspect}. #{phrase.inspect} is NOT a pangram"
+  end
+
+  def test_pangram_with_underscores
+    skip
+    phrase = 'the_quick_brown_fox_jumps_over_the_lazy_dog'
+    result = Pangram.pangram?(phrase)
+    assert result, "Expected true, got: #{result.inspect}. #{phrase.inspect} IS a pangram"
+  end
+
+  def test_pangram_with_numbers
+    skip
+    phrase = 'the 1 quick brown fox jumps over the 2 lazy dogs'
+    result = Pangram.pangram?(phrase)
+    assert result, "Expected true, got: #{result.inspect}. #{phrase.inspect} IS a pangram"
+  end
+
+  def test_missing_letters_replaced_by_numbers
+    skip
+    phrase = '7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog'
+    result = Pangram.pangram?(phrase)
+    refute result, "Expected false, got: #{result.inspect}. #{phrase.inspect} is NOT a pangram"
+  end
+
+  def test_pangram_with_mixed_case_and_punctuation
+    skip
+    phrase = '"Five quacking Zephyrs jolt my wax bed."'
+    result = Pangram.pangram?(phrase)
+    assert result, "Expected true, got: #{result.inspect}. #{phrase.inspect} IS a pangram"
+  end
+
+  def test_upper_and_lower_case_versions_of_the_same_character_should_not_be_counted_separately
+    skip
+    phrase = 'the quick brown fox jumps over with lazy FX'
+    result = Pangram.pangram?(phrase)
+    refute result, "Expected false, got: #{result.inspect}. #{phrase.inspect} is NOT a pangram"
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 6, BookKeeping::VERSION
+  end
+end

--- a/exercises/pascals-triangle/README.md
+++ b/exercises/pascals-triangle/README.md
@@ -1,0 +1,45 @@
+# Pascal's Triangle
+
+Compute Pascal's triangle up to a given number of rows.
+
+In Pascal's Triangle each number is computed by adding the numbers to
+the right and left of the current position in the previous row.
+
+```text
+    1
+   1 1
+  1 2 1
+ 1 3 3 1
+1 4 6 4 1
+# ... etc
+```
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby pascals_triangle_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride pascals_triangle_test.rb
+
+
+## Source
+
+Pascal's Triangle at Wolfram Math World [http://mathworld.wolfram.com/PascalsTriangle.html](http://mathworld.wolfram.com/PascalsTriangle.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/pascals-triangle/pascals_triangle_test.rb
+++ b/exercises/pascals-triangle/pascals_triangle_test.rb
@@ -1,0 +1,43 @@
+require 'minitest/autorun'
+require_relative 'pascals_triangle'
+
+class TriangleTest < Minitest::Test
+  def test_one_row
+    triangle = Triangle.new(1)
+    assert_equal [[1]], triangle.rows
+  end
+
+  def test_two_rows
+    skip
+    triangle = Triangle.new(2)
+    assert_equal [[1], [1, 1]], triangle.rows
+  end
+
+  def test_three_rows
+    skip
+    triangle = Triangle.new(3)
+    assert_equal [[1], [1, 1], [1, 2, 1]], triangle.rows
+  end
+
+  def test_fourth_row
+    skip
+    triangle = Triangle.new(4)
+    assert_equal [1, 3, 3, 1], triangle.rows.last
+  end
+
+  def test_fifth_row
+    skip
+    triangle = Triangle.new(5)
+    assert_equal [1, 4, 6, 4, 1], triangle.rows.last
+  end
+
+  def test_twentieth_row
+    skip
+    triangle = Triangle.new(20)
+    expected = [
+      1, 19, 171, 969, 3876, 11_628, 27_132, 50_388, 75_582, 92_378, 92_378,
+      75_582, 50_388, 27_132, 11_628, 3876, 969, 171, 19, 1
+    ]
+    assert_equal expected, triangle.rows.last
+  end
+end

--- a/exercises/perfect-numbers/README.md
+++ b/exercises/perfect-numbers/README.md
@@ -1,0 +1,48 @@
+# Perfect Numbers
+
+Determine if a number is perfect, abundant, or deficient based on
+Nicomachus' (60 - 120 CE) classification scheme for natural numbers.
+
+The Greek mathematician [Nicomachus](https://en.wikipedia.org/wiki/Nicomachus) devised a classification scheme for natural numbers, identifying each as belonging uniquely to the categories of **perfect**, **abundant**, or **deficient** based on their [aliquot sum](https://en.wikipedia.org/wiki/Aliquot_sum). The aliquot sum is defined as the sum of the factors of a number not including the number itself. For example, the aliquot sum of 15 is (1 + 3 + 5) = 9
+
+- **Perfect**: aliquot sum = number
+  - 6 is a perfect number because (1 + 2 + 3) = 6
+  - 28 is a perfect number because (1 + 2 + 4 + 7 + 14) = 28
+- **Abundant**: aliquot sum > number
+  - 12 is an abundant number because (1 + 2 + 3 + 4 + 6) = 16
+  - 24 is an abundant number because (1 + 2 + 3 + 4 + 6 + 8 + 12) = 36
+- **Deficient**: aliquot sum < number
+  - 8 is a deficient number because (1 + 2 + 4) = 7
+  - Prime numbers are deficient
+
+Implement a way to determine whether a given number is **perfect**. Depending on your language track, you may also need to implement a way to determine whether a given number is **abundant** or **deficient**.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby perfect_numbers_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride perfect_numbers_test.rb
+
+
+## Source
+
+Taken from Chapter 2 of Functional Thinking by Neal Ford. [http://shop.oreilly.com/product/0636920029687.do](http://shop.oreilly.com/product/0636920029687.do)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/perfect-numbers/perfect_numbers_test.rb
+++ b/exercises/perfect-numbers/perfect_numbers_test.rb
@@ -1,0 +1,26 @@
+require 'minitest/autorun'
+require_relative 'perfect_numbers'
+
+class PerfectNumberTest < Minitest::Test
+  def test_initialize_perfect_number
+    assert_raises RuntimeError do
+      PerfectNumber.classify(-1)
+    end
+  end
+
+  def test_classify_deficient
+    assert_equal 'deficient', PerfectNumber.classify(13)
+  end
+
+  def test_classify_perfect
+    assert_equal 'perfect', PerfectNumber.classify(28)
+  end
+
+  def test_classify_abundant
+    assert_equal 'abundant', PerfectNumber.classify(12)
+  end
+
+  def test_bookkeeping
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -1,0 +1,59 @@
+# Phone Number
+
+Clean up user-entered phone numbers so that they can be sent SMS messages.
+
+The **North American Numbering Plan (NANP)** is a telephone numbering system used by many countries in North America like the United States, Canada or Bermuda. All NANP-countries share the same international country code: `1`.
+
+NANP numbers are ten-digit numbers consisting of a three-digit Numbering Plan Area code, commonly known as *area code*, followed by a seven-digit local number. The first three digits of the local number represent the *exchange code*, followed by the unique four-digit number which is the *subscriber number*.
+
+The format is usually represented as
+
+```text
+(NXX)-NXX-XXXX
+```
+
+where `N` is any digit from 2 through 9 and `X` is any digit from 0 through 9.
+
+Your task is to clean up differently formatted telephone numbers by removing punctuation and the country code (1) if present.
+
+For example, the inputs
+- `+1 (613)-995-0253`
+- `613-995-0253`
+- `1 613 995 0253`
+- `613.995.0253`
+
+should all produce the output
+
+`6139950253`
+
+**Note:** As this exercise only deals with telephone numbers used in NANP-countries, only 1 is considered a valid country code.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby phone_number_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride phone_number_test.rb
+
+
+## Source
+
+Event Manager by JumpstartLab [http://tutorials.jumpstartlab.com/projects/eventmanager.html](http://tutorials.jumpstartlab.com/projects/eventmanager.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/phone-number/phone_number_test.rb
+++ b/exercises/phone-number/phone_number_test.rb
@@ -1,0 +1,87 @@
+require 'minitest/autorun'
+require_relative 'phone_number'
+
+# Common test data version: 1.2.0 39cba0d
+class PhoneNumberTest < Minitest::Test
+  def test_cleans_the_number
+    # skip
+    assert_equal "2234567890", PhoneNumber.clean("(223) 456-7890")
+  end
+
+  def test_cleans_numbers_with_dots
+    skip
+    assert_equal "2234567890", PhoneNumber.clean("223.456.7890")
+  end
+
+  def test_cleans_numbers_with_multiple_spaces
+    skip
+    assert_equal "2234567890", PhoneNumber.clean("223 456   7890   ")
+  end
+
+  def test_invalid_when_9_digits
+    skip
+    assert_nil PhoneNumber.clean("123456789")
+  end
+
+  def test_invalid_when_11_digits_does_not_start_with_a_1
+    skip
+    assert_nil PhoneNumber.clean("22234567890")
+  end
+
+  def test_valid_when_11_digits_and_starting_with_1
+    skip
+    assert_equal "2234567890", PhoneNumber.clean("12234567890")
+  end
+
+  def test_valid_when_11_digits_and_starting_with_1_even_with_punctuation
+    skip
+    assert_equal "2234567890", PhoneNumber.clean("+1 (223) 456-7890")
+  end
+
+  def test_invalid_when_more_than_11_digits
+    skip
+    assert_nil PhoneNumber.clean("321234567890")
+  end
+
+  def test_invalid_with_letters
+    skip
+    assert_nil PhoneNumber.clean("123-abc-7890")
+  end
+
+  def test_invalid_with_punctuations
+    skip
+    assert_nil PhoneNumber.clean("123-@:!-7890")
+  end
+
+  def test_invalid_if_area_code_does_not_start_with_2_9
+    skip
+    assert_nil PhoneNumber.clean("(123) 456-7890")
+  end
+
+  def test_invalid_if_exchange_code_does_not_start_with_2_9
+    skip
+    assert_nil PhoneNumber.clean("(223) 056-7890")
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 2, BookKeeping::VERSION
+  end
+end

--- a/exercises/pig-latin/README.md
+++ b/exercises/pig-latin/README.md
@@ -1,0 +1,48 @@
+# Pig Latin
+
+Implement a program that translates from English to Pig Latin.
+
+Pig Latin is a made-up children's language that's intended to be
+confusing. It obeys a few simple rules (below), but when it's spoken
+quickly it's really difficult for non-children (and non-native speakers)
+to understand.
+
+- **Rule 1**: If a word begins with a vowel sound, add an "ay" sound to
+  the end of the word.
+- **Rule 2**: If a word begins with a consonant sound, move it to the
+  end of the word, and then add an "ay" sound to the end of the word.
+
+There are a few more rules for edge cases, and there are regional
+variants too.
+
+See <http://en.wikipedia.org/wiki/Pig_latin> for more details.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby pig_latin_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride pig_latin_test.rb
+
+
+## Source
+
+The Pig Latin exercise at Test First Teaching by Ultrasaurus [https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/](https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/pig-latin/pig_latin_test.rb
+++ b/exercises/pig-latin/pig_latin_test.rb
@@ -1,0 +1,137 @@
+require 'minitest/autorun'
+require_relative 'pig_latin'
+
+# Common test data version: 1.1.0 b5ddd0a
+class PigLatinTest < Minitest::Test
+  def test_word_beginning_with_a
+    # skip
+    assert_equal "appleay", PigLatin.translate("apple")
+  end
+
+  def test_word_beginning_with_e
+    skip
+    assert_equal "earay", PigLatin.translate("ear")
+  end
+
+  def test_word_beginning_with_i
+    skip
+    assert_equal "iglooay", PigLatin.translate("igloo")
+  end
+
+  def test_word_beginning_with_o
+    skip
+    assert_equal "objectay", PigLatin.translate("object")
+  end
+
+  def test_word_beginning_with_u
+    skip
+    assert_equal "underay", PigLatin.translate("under")
+  end
+
+  def test_word_beginning_with_a_vowel_and_followed_by_a_qu
+    skip
+    assert_equal "equalay", PigLatin.translate("equal")
+  end
+
+  def test_word_beginning_with_p
+    skip
+    assert_equal "igpay", PigLatin.translate("pig")
+  end
+
+  def test_word_beginning_with_k
+    skip
+    assert_equal "oalakay", PigLatin.translate("koala")
+  end
+
+  def test_word_beginning_with_x
+    skip
+    assert_equal "enonxay", PigLatin.translate("xenon")
+  end
+
+  def test_word_beginning_with_q_without_a_following_u
+    skip
+    assert_equal "atqay", PigLatin.translate("qat")
+  end
+
+  def test_word_beginning_with_ch
+    skip
+    assert_equal "airchay", PigLatin.translate("chair")
+  end
+
+  def test_word_beginning_with_qu
+    skip
+    assert_equal "eenquay", PigLatin.translate("queen")
+  end
+
+  def test_word_beginning_with_qu_and_a_preceding_consonant
+    skip
+    assert_equal "aresquay", PigLatin.translate("square")
+  end
+
+  def test_word_beginning_with_th
+    skip
+    assert_equal "erapythay", PigLatin.translate("therapy")
+  end
+
+  def test_word_beginning_with_thr
+    skip
+    assert_equal "ushthray", PigLatin.translate("thrush")
+  end
+
+  def test_word_beginning_with_sch
+    skip
+    assert_equal "oolschay", PigLatin.translate("school")
+  end
+
+  def test_word_beginning_with_yt
+    skip
+    assert_equal "yttriaay", PigLatin.translate("yttria")
+  end
+
+  def test_word_beginning_with_xr
+    skip
+    assert_equal "xrayay", PigLatin.translate("xray")
+  end
+
+  def test_y_is_treated_like_a_consonant_at_the_beginning_of_a_word
+    skip
+    assert_equal "ellowyay", PigLatin.translate("yellow")
+  end
+
+  def test_y_is_treated_like_a_vowel_at_the_end_of_a_consonant_cluster
+    skip
+    assert_equal "ythmrhay", PigLatin.translate("rhythm")
+  end
+
+  def test_y_as_second_letter_in_two_letter_word
+    skip
+    assert_equal "ymay", PigLatin.translate("my")
+  end
+
+  def test_a_whole_phrase
+    skip
+    assert_equal "ickquay astfay unray", PigLatin.translate("quick fast run")
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 2, BookKeeping::VERSION
+  end
+end

--- a/exercises/point-mutations/README.md
+++ b/exercises/point-mutations/README.md
@@ -1,0 +1,65 @@
+# Point Mutations
+
+Calculate the Hamming difference between two DNA strands.
+
+A mutation is simply a mistake that occurs during the creation or
+copying of a nucleic acid, in particular DNA. Because nucleic acids are
+vital to cellular functions, mutations tend to cause a ripple effect
+throughout the cell. Although mutations are technically mistakes, a very
+rare mutation may equip the cell with a beneficial attribute. In fact,
+the macro effects of evolution are attributable by the accumulated
+result of beneficial microscopic mutations over many generations.
+
+The simplest and most common type of nucleic acid mutation is a point
+mutation, which replaces one base with another at a single nucleotide.
+
+By counting the number of differences between two homologous DNA strands
+taken from different genomes with a common ancestor, we get a measure of
+the minimum number of point mutations that could have occurred on the
+evolutionary path between the two strands.
+
+This is called the 'Hamming distance'
+
+    GAGCCTACTAACGGGAT
+    CATCGTAATGACGGCCT
+    ^ ^ ^  ^ ^    ^^
+
+The Hamming distance between these two DNA strands is 7.
+
+# Implementation notes
+
+The Hamming distance is only defined for sequences of equal length. Hence you
+may assume that only sequences of equal length will be passed to your hamming
+distance function.
+
+**Note: This problem is deprecated, replaced by the one called `hamming`.**
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby point_mutations_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride point_mutations_test.rb
+
+
+## Source
+
+The Calculating Point Mutations problem at Rosalind [http://rosalind.info/problems/hamm/](http://rosalind.info/problems/hamm/)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/point-mutations/point_mutations_test.rb
+++ b/exercises/point-mutations/point_mutations_test.rb
@@ -1,0 +1,55 @@
+require 'minitest/autorun'
+require_relative 'point_mutations'
+
+class DNATest < Minitest::Test
+  def test_no_difference_between_empty_strands
+    assert_equal 0, DNA.new('').hamming_distance('')
+  end
+
+  def test_no_difference_between_identical_strands
+    skip
+    assert_equal 0, DNA.new('GGACTGA').hamming_distance('GGACTGA')
+  end
+
+  def test_complete_hamming_distance_in_small_strand
+    skip
+    assert_equal 3, DNA.new('ACT').hamming_distance('GGA')
+  end
+
+  def test_hamming_distance_in_off_by_one_strand
+    skip
+    strand = 'GGACGGATTCTGACCTGGACTAATTTTGGGG'
+    distance = 'AGGACGGATTCTGACCTGGACTAATTTTGGGG'
+    assert_equal 19, DNA.new(strand).hamming_distance(distance)
+  end
+
+  def test_small_hamming_distance_in_middle_somewhere
+    skip
+    assert_equal 1, DNA.new('GGACG').hamming_distance('GGTCG')
+  end
+
+  def test_larger_distance
+    skip
+    assert_equal 2, DNA.new('ACCAGGG').hamming_distance('ACTATGG')
+  end
+
+  def test_ignores_extra_length_on_other_strand_when_longer
+    skip
+    assert_equal 3, DNA.new('AAACTAGGGG').hamming_distance('AGGCTAGCGGTAGGAC')
+  end
+
+  def test_ignores_extra_length_on_original_strand_when_longer
+    skip
+    strand = 'GACTACGGACAGGGTAGGGAAT'
+    distance = 'GACATCGCACACC'
+    assert_equal 5, DNA.new(strand).hamming_distance(distance)
+  end
+
+  def test_does_not_actually_shorten_original_strand
+    skip
+    dna = DNA.new('AGACAACAGCCAGCCGCCGGATT')
+    assert_equal 1, dna.hamming_distance('AGGCAA')
+    assert_equal 4, dna.hamming_distance('AGACATCTTTCAGCCGCCGGATTAGGCAA')
+    assert_equal 1, dna.hamming_distance('AGG')
+  end
+end

--- a/exercises/poker/README.md
+++ b/exercises/poker/README.md
@@ -1,0 +1,36 @@
+# Poker
+
+Pick the best hand(s) from a list of poker hands.
+
+See [wikipedia](https://en.wikipedia.org/wiki/List_of_poker_hands) for an
+overview of poker hands.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby poker_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride poker_test.rb
+
+
+## Source
+
+Inspired by the training course from Udacity. [https://www.udacity.com/course/viewer#!/c-cs212/](https://www.udacity.com/course/viewer#!/c-cs212/)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/poker/poker_test.rb
+++ b/exercises/poker/poker_test.rb
@@ -1,0 +1,200 @@
+require 'minitest/autorun'
+require_relative 'poker'
+
+class PokerTest < Minitest::Test
+  def test_one_hand
+    high_of_jack = %w(4S 5S 7H 8D JC)
+    game = Poker.new([high_of_jack])
+    assert_equal [high_of_jack], game.best_hand
+  end
+
+  def test_highest_card
+    skip
+    high_of_8 = %w(4S 5H 6S 8D 2H)
+    high_of_queen = %w(2S 4H 6C 9D QH)
+    game = Poker.new([high_of_8, high_of_queen])
+    assert_equal [high_of_queen], game.best_hand
+  end
+
+  def test_highest_card_10
+    skip
+    high_of_8 = %w(4D 5S 6S 8D 3C)
+    high_of_10 = %w(2S 4C 7S 9H 10H)
+    game = Poker.new([high_of_8, high_of_10])
+    assert_equal [high_of_10], game.best_hand
+  end
+
+  def test_nothing_vs_one_pair
+    skip
+    high_of_king = %w(4S 5H 6C 8D KH)
+    pair_of_4 = %w(2S 4H 6S 4D JH)
+    game = Poker.new([high_of_king, pair_of_4])
+    assert_equal [pair_of_4], game.best_hand
+  end
+
+  def test_two_pair
+    skip
+    pair_of_2 = %w(4S 2H 6S 2D JH)
+    pair_of_4 = %w(2S 4H 6C 4D JD)
+    game = Poker.new([pair_of_2, pair_of_4])
+    assert_equal [pair_of_4], game.best_hand
+  end
+
+  def test_one_pair_vs_double_pair
+    skip
+    pair_of_8 = %w(2S 8H 6S 8D JH)
+    fives_and_fours = %w(4S 5H 4C 8C 5C)
+    game = Poker.new([pair_of_8, fives_and_fours])
+    assert_equal [fives_and_fours], game.best_hand
+  end
+
+  def test_two_double_pair
+    skip
+    eights_and_twos = %w(2S 8H 2D 8D 3H)
+    fives_and_fours = %w(4S 5H 4C 8S 5D)
+    game = Poker.new([eights_and_twos, fives_and_fours])
+    assert_equal [eights_and_twos], game.best_hand
+  end
+
+  def test_another_two_double_pair
+    skip
+    aces_and_twos = %w(2S AH 2C AD JH)
+    queens_and_jacks = %w(JD QH JS 8D QC)
+    game = Poker.new([aces_and_twos, queens_and_jacks])
+    assert_equal [aces_and_twos], game.best_hand
+  end
+
+  def test_double_pair_vs_three
+    skip
+    eights_and_twos = %w(2S 8H 2H 8D JH)
+    three_of_4 = %w(4S 5H 4C 8S 4H)
+    game = Poker.new([eights_and_twos, three_of_4])
+    assert_equal [three_of_4], game.best_hand
+  end
+
+  def test_two_three
+    skip
+    three_twos = %w(2S 2H 2C 8D JH)
+    three_aces = %w(4S AH AS 8C AD)
+    game = Poker.new([three_twos, three_aces])
+    assert_equal [three_aces], game.best_hand
+  end
+
+  def test_three_vs_straight
+    skip
+    three_of_4 = %w(4S 5H 4C 8D 4H)
+    straight = %w(3S 4D 2S 6D 5C)
+    game = Poker.new([three_of_4, straight])
+    assert_equal [straight], game.best_hand
+  end
+
+  def test_a_5_high_straight
+    skip
+    three_of_4 = %w(4S 5H 4C 8D 4H)
+    straight_to_5 = %w(4D AH 3S 2D 5C)
+    game = Poker.new([three_of_4, straight_to_5])
+    assert_equal [straight_to_5], game.best_hand
+  end
+
+  def test_two_straights
+    skip
+    straight_to_8 = %w(4S 6C 7S 8D 5H)
+    straight_to_9 = %w(5S 7H 8S 9D 6H)
+    game = Poker.new([straight_to_8, straight_to_9])
+    assert_equal [straight_to_9], game.best_hand
+  end
+
+  def test_5_high_straight_vs_other_straight
+    skip
+    straight_to_jack = %w(8H 7C 10D 9D JH)
+    straight_to_5 = %w(4S AH 3S 2D 5H)
+    game = Poker.new([straight_to_jack, straight_to_5])
+    assert_equal [straight_to_jack], game.best_hand
+  end
+
+  def test_straight_vs_flush
+    skip
+    straight_to_8 = %w(4C 6H 7D 8D 5H)
+    flush_to_7 = %w(2S 4S 5S 6S 7S)
+    game = Poker.new([straight_to_8, flush_to_7])
+    assert_equal [flush_to_7], game.best_hand
+  end
+
+  def test_two_flushes
+    skip
+    flush_to_8 = %w(3H 6H 7H 8H 5H)
+    flush_to_7 = %w(2S 4S 5S 6S 7S)
+    game = Poker.new([flush_to_8, flush_to_7])
+    assert_equal [flush_to_8], game.best_hand
+  end
+
+  def test_flush_vs_full
+    skip
+    flush_to_8 = %w(3H 6H 7H 8H 5C)
+    full = %w(4S 5H 4C 5D 4H)
+    game = Poker.new([flush_to_8, full])
+    assert_equal [full], game.best_hand
+  end
+
+  def test_two_fulls
+    skip
+    full_of_4_by_9 = %w(4H 4S 4D 9S 9D)
+    full_of_5_by_8 = %w(5H 5S 5D 8S 8D)
+    game = Poker.new([full_of_4_by_9, full_of_5_by_8])
+    assert_equal [full_of_5_by_8], game.best_hand
+  end
+
+  def test_full_vs_square
+    skip
+    full = %w(4S 5H 4D 5D 4H)
+    square_of_3 = %w(3S 3H 2S 3D 3C)
+    game = Poker.new([square_of_3, full])
+    assert_equal [square_of_3], game.best_hand
+  end
+
+  def test_two_square
+    skip
+    square_of_2 = %w(2S 2H 2C 8D 2D)
+    square_of_5 = %w(4S 5H 5S 5D 5C)
+    game = Poker.new([square_of_2, square_of_5])
+    assert_equal [square_of_5], game.best_hand
+  end
+
+  def test_square_vs_straight_flush
+    skip
+    square_of_5 = %w(4S 5H 5S 5D 5C)
+    straight_flush_to_10 = %w(7S 8S 9S 6S 10S)
+    game = Poker.new([square_of_5, straight_flush_to_10])
+    assert_equal [straight_flush_to_10], game.best_hand
+  end
+
+  def test_two_straight_flushes
+    skip
+    straight_flush_to_8 = %w(4H 6H 7H 8H 5H)
+    straight_flush_to_9 = %w(5S 7S 8S 9S 6S)
+    game = Poker.new([straight_flush_to_8, straight_flush_to_9])
+    assert_equal [straight_flush_to_9], game.best_hand
+  end
+
+  def test_highest_card_down_to_fifth_card
+    skip
+    high_of_8_low_of_3 = %w(3S 5H 6S 8D 7H)
+    high_of_8_low_of_2 = %w(2S 5D 6D 8C 7S)
+    game = Poker.new([high_of_8_low_of_3, high_of_8_low_of_2])
+    assert_equal [high_of_8_low_of_3], game.best_hand
+  end
+
+  def test_three_hand_with_tie
+    skip
+    spade_straight_to_9 = %w(9S 8S 7S 6S 5S)
+    diamond_straight_to_9 = %w(9D 8D 7D 6D 5D)
+    three_of_4 = %w(4D 4S 4H QS KS)
+    hands = [spade_straight_to_9, diamond_straight_to_9, three_of_4]
+    game = Poker.new(hands)
+    assert_equal [spade_straight_to_9, diamond_straight_to_9], game.best_hand
+  end
+
+  def test_bookkeeping
+    assert_equal 2, BookKeeping::VERSION
+  end
+end

--- a/exercises/prime-factors/README.md
+++ b/exercises/prime-factors/README.md
@@ -1,0 +1,60 @@
+# Prime Factors
+
+Compute the prime factors of a given natural number.
+
+A prime number is only evenly divisible by itself and 1.
+
+Note that 1 is not a prime number.
+
+## Example
+
+What are the prime factors of 60?
+
+- Our first divisor is 2. 2 goes into 60, leaving 30.
+- 2 goes into 30, leaving 15.
+  - 2 doesn't go cleanly into 15. So let's move on to our next divisor, 3.
+- 3 goes cleanly into 15, leaving 5.
+  - 3 does not go cleanly into 5. The next possible factor is 4.
+  - 4 does not go cleanly into 5. The next possible factor is 5.
+- 5 does go cleanly into 5.
+- We're left only with 1, so now, we're done.
+
+Our successful divisors in that computation represent the list of prime
+factors of 60: 2, 2, 3, and 5.
+
+You can check this yourself:
+
+- 2 * 2 * 3 * 5
+- = 4 * 15
+- = 60
+- Success!
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby prime_factors_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride prime_factors_test.rb
+
+
+## Source
+
+The Prime Factors Kata by Uncle Bob [http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata](http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/prime-factors/prime_factors_test.rb
+++ b/exercises/prime-factors/prime_factors_test.rb
@@ -1,0 +1,58 @@
+require 'minitest/autorun'
+require_relative 'prime_factors'
+
+class PrimeFactorsTest < Minitest::Test
+  def test_1
+    assert_equal [], PrimeFactors.for(1)
+  end
+
+  def test_2
+    skip
+    assert_equal [2], PrimeFactors.for(2)
+  end
+
+  def test_3
+    skip
+    assert_equal [3], PrimeFactors.for(3)
+  end
+
+  def test_4
+    skip
+    assert_equal [2, 2], PrimeFactors.for(4)
+  end
+
+  def test_6
+    skip
+    assert_equal [2, 3], PrimeFactors.for(6)
+  end
+
+  def test_8
+    skip
+    assert_equal [2, 2, 2], PrimeFactors.for(8)
+  end
+
+  def test_9
+    skip
+    assert_equal [3, 3], PrimeFactors.for(9)
+  end
+
+  def test_27
+    skip
+    assert_equal [3, 3, 3], PrimeFactors.for(27)
+  end
+
+  def test_625
+    skip
+    assert_equal [5, 5, 5, 5], PrimeFactors.for(625)
+  end
+
+  def test_901255
+    skip
+    assert_equal [5, 17, 23, 461], PrimeFactors.for(901_255)
+  end
+
+  def test_93819012551
+    skip
+    assert_equal [11, 9539, 894_119], PrimeFactors.for(93_819_012_551)
+  end
+end

--- a/exercises/protein-translation/README.md
+++ b/exercises/protein-translation/README.md
@@ -1,0 +1,72 @@
+# Protein Translation
+
+Translate RNA sequences into proteins.
+
+RNA can be broken into three nucleotide sequences called codons, and then translated to a polypeptide like so:
+
+RNA: `"AUGUUUUCU"` => translates to
+
+Codons: `"AUG", "UUU", "UCU"`
+=> which become a polypeptide with the following sequence =>
+
+Protein: `"Methionine", "Phenylalanine", "Serine"`
+
+There are 64 codons which in turn correspond to 20 amino acids; however, all of the codon sequences and resulting amino acids are not important in this exercise.  If it works for one codon, the program should work for all of them.
+However, feel free to expand the list in the test suite to include them all.
+
+There are also three terminating codons (also known as 'STOP' codons); if any of these codons are encountered (by the ribosome), all translation ends and the protein is terminated.
+
+All subsequent codons after are ignored, like this:
+
+RNA: `"AUGUUUUCUUAAAUG"` =>
+
+Codons: `"AUG", "UUU", "UCU", "UAG", "AUG"` =>
+
+Protein: `"Methionine", "Phenylalanine", "Serine"`
+
+Note the stop codon terminates the translation and the final methionine is not translated into the protein sequence.
+
+Below are the codons and resulting Amino Acids needed for the exercise.
+
+Codon                 | Protein
+:---                  | :---
+AUG                   | Methionine
+UUU, UUC              | Phenylalanine
+UUA, UUG              | Leucine
+UCU, UCC, UCA, UCG    | Serine
+UAU, UAC              | Tyrosine
+UGU, UGC              | Cysteine
+UGG                   | Tryptophan
+UAA, UAG, UGA         | STOP
+
+Learn more about [protein translation on Wikipedia](http://en.wikipedia.org/wiki/Translation_(biology))
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby protein_translation_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride protein_translation_test.rb
+
+
+## Source
+
+Tyler Long
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/protein-translation/protein_translation_test.rb
+++ b/exercises/protein-translation/protein_translation_test.rb
@@ -1,0 +1,83 @@
+require 'minitest/autorun'
+require_relative 'protein_translation'
+
+class TranslationTest < Minitest::Test
+  def test_AUG_translates_to_methionine
+    assert_equal 'Methionine', Translation.of_codon('AUG')
+  end
+
+  def test_identifies_Phenylalanine_codons
+    skip
+    assert_equal 'Phenylalanine', Translation.of_codon('UUU')
+    assert_equal 'Phenylalanine', Translation.of_codon('UUC')
+  end
+
+  def test_identifies_Leucine_codons
+    skip
+    %w(UUA UUG).each do |codon|
+      assert_equal 'Leucine', Translation.of_codon(codon)
+    end
+  end
+
+  def test_identifies_Serine_codons
+    skip
+    %w(UCU UCC UCA UCG).each do |codon|
+      assert_equal 'Serine', Translation.of_codon(codon)
+    end
+  end
+
+  def test_identifies_Tyrosine_codons
+    skip
+    %w(UAU UAC).each do |codon|
+      assert_equal 'Tyrosine', Translation.of_codon(codon)
+    end
+  end
+
+  def test_identifies_Cysteine_codons
+    skip
+    %w(UGU UGC).each do |codon|
+      assert_equal 'Cysteine', Translation.of_codon(codon)
+    end
+  end
+
+  def test_identifies_Tryptophan_codons
+    skip
+    assert_equal 'Tryptophan', Translation.of_codon('UGG')
+  end
+
+  def test_identifies_stop_codons
+    skip
+    %w(UAA UAG UGA).each do |codon|
+      assert_equal 'STOP', Translation.of_codon(codon)
+    end
+  end
+
+  def test_translates_rna_strand_into_correct_protein
+    skip
+    strand = 'AUGUUUUGG'
+    expected = %w(Methionine Phenylalanine Tryptophan)
+    assert_equal expected, Translation.of_rna(strand)
+  end
+
+  def test_stops_translation_if_stop_codon_present
+    skip
+    strand = 'AUGUUUUAA'
+    expected = %w(Methionine Phenylalanine)
+    assert_equal expected, Translation.of_rna(strand)
+  end
+
+  def test_stops_translation_of_longer_strand
+    skip
+    strand = 'UGGUGUUAUUAAUGGUUU'
+    expected = %w(Tryptophan Cysteine Tyrosine)
+    assert_equal expected, Translation.of_rna(strand)
+  end
+
+  def test_invalid_codons
+    skip
+    strand = 'CARROT'
+    assert_raises(InvalidCodonError) do
+      Translation.of_rna(strand)
+    end
+  end
+end

--- a/exercises/proverb/README.md
+++ b/exercises/proverb/README.md
@@ -1,0 +1,47 @@
+# Proverb
+
+For want of a horseshoe nail, a kingdom was lost, or so the saying goes.
+
+Given a list of inputs, generate the relevant proverb. For example, given the list `["nail", "shoe", "horse", "rider", "message", "battle", "kingdom"]`, you will output the full text of this proverbial rhyme:
+
+```text
+For want of a nail the shoe was lost.
+For want of a shoe the horse was lost.
+For want of a horse the rider was lost.
+For want of a rider the message was lost.
+For want of a message the battle was lost.
+For want of a battle the kingdom was lost.
+And all for the want of a nail.
+```
+
+Note that the list of inputs may vary; your solution should be able to handle lists of arbitrary length and content. No line of the output text should be a static, unchanging string; all should vary according to the input given.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby proverb_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride proverb_test.rb
+
+
+## Source
+
+Wikipedia [http://en.wikipedia.org/wiki/For_Want_of_a_Nail](http://en.wikipedia.org/wiki/For_Want_of_a_Nail)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/proverb/proverb_test.rb
+++ b/exercises/proverb/proverb_test.rb
@@ -1,0 +1,72 @@
+require 'minitest/autorun'
+require_relative 'proverb'
+
+class ProverbTest < Minitest::Test
+  def test_a_single_consequence
+    proverb = Proverb.new('nail', 'shoe')
+    expected = "For want of a nail the shoe was lost.\n" \
+      'And all for the want of a nail.'
+    assert_equal expected, proverb.to_s
+  end
+
+  def test_a_short_chain_of_consequences
+    skip
+    proverb = Proverb.new('nail', 'shoe', 'horse')
+    expected = "For want of a nail the shoe was lost.\n" \
+      "For want of a shoe the horse was lost.\n" \
+      'And all for the want of a nail.'
+    assert_equal expected, proverb.to_s
+  end
+
+  def test_a_longer_chain_of_consequences
+    skip
+    proverb = Proverb.new('nail', 'shoe', 'horse', 'rider')
+    expected = "For want of a nail the shoe was lost.\n" \
+      "For want of a shoe the horse was lost.\n" \
+      "For want of a horse the rider was lost.\n" \
+      'And all for the want of a nail.'
+    assert_equal expected, proverb.to_s
+  end
+
+  def test_proverb_does_not_hard_code_the_rhyme_dictionary
+    skip
+    proverb = Proverb.new('key', 'value')
+    expected = "For want of a key the value was lost.\n" \
+      'And all for the want of a key.'
+    assert_equal expected, proverb.to_s
+  end
+
+  def test_the_whole_proverb
+    skip
+    chain = %w(nail shoe horse rider message battle kingdom)
+    proverb = Proverb.new(*chain)
+    expected = "For want of a nail the shoe was lost.\n" \
+      "For want of a shoe the horse was lost.\n" \
+      "For want of a horse the rider was lost.\n" \
+      "For want of a rider the message was lost.\n" \
+      "For want of a message the battle was lost.\n" \
+      "For want of a battle the kingdom was lost.\n" \
+      'And all for the want of a nail.'
+    assert_equal expected, proverb.to_s
+  end
+
+  def test_an_optional_qualifier_in_the_final_consequence
+    skip
+    chain = %w(nail shoe horse rider message battle kingdom)
+    proverb = Proverb.new(*chain, qualifier: 'horseshoe')
+    expected = "For want of a nail the shoe was lost.\n" \
+      "For want of a shoe the horse was lost.\n" \
+      "For want of a horse the rider was lost.\n" \
+      "For want of a rider the message was lost.\n" \
+      "For want of a message the battle was lost.\n" \
+      "For want of a battle the kingdom was lost.\n" \
+      'And all for the want of a horseshoe nail.'
+    assert_equal expected, proverb.to_s
+  end
+
+  def test_proverb_is_same_each_time
+    skip
+    proverb = Proverb.new('nail', 'shoe')
+    assert_equal proverb.to_s, proverb.to_s
+  end
+end

--- a/exercises/pythagorean-triplet/README.md
+++ b/exercises/pythagorean-triplet/README.md
@@ -1,0 +1,48 @@
+# Pythagorean Triplet
+
+A Pythagorean triplet is a set of three natural numbers, {a, b, c}, for
+which,
+
+```text
+a**2 + b**2 = c**2
+```
+
+For example,
+
+```text
+3**2 + 4**2 = 9 + 16 = 25 = 5**2.
+```
+
+There exists exactly one Pythagorean triplet for which a + b + c = 1000.
+
+Find the product a * b * c.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby pythagorean_triplet_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride pythagorean_triplet_test.rb
+
+
+## Source
+
+Problem 9 at Project Euler [http://projecteuler.net/problem=9](http://projecteuler.net/problem=9)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/pythagorean-triplet/pythagorean_triplet_test.rb
+++ b/exercises/pythagorean-triplet/pythagorean_triplet_test.rb
@@ -1,0 +1,44 @@
+require 'minitest/autorun'
+require_relative 'pythagorean_triplet'
+
+class TripletTest < Minitest::Test
+  def test_sum
+    assert_equal 12, Triplet.new(3, 4, 5).sum
+  end
+
+  def test_product
+    skip
+    assert_equal 60, Triplet.new(3, 4, 5).product
+  end
+
+  def test_pythagorean
+    skip
+    assert Triplet.new(3, 4, 5).pythagorean?
+  end
+
+  def test_not_pythagorean
+    skip
+    refute Triplet.new(5, 6, 7).pythagorean?
+  end
+
+  def test_triplets_upto_10
+    skip
+    triplets = Triplet.where(max_factor: 10)
+    products = triplets.map(&:product).sort
+    assert_equal [60, 480], products
+  end
+
+  def test_triplets_from_11_upto_20
+    skip
+    triplets = Triplet.where(min_factor: 11, max_factor: 20)
+    products = triplets.map(&:product).sort
+    assert_equal [3840], products
+  end
+
+  def test_triplets_where_sum_x
+    skip
+    triplets = Triplet.where(sum: 180, max_factor: 100)
+    products = triplets.map(&:product).sort
+    assert_equal [118_080, 168_480, 202_500], products
+  end
+end

--- a/exercises/queen-attack/README.md
+++ b/exercises/queen-attack/README.md
@@ -1,0 +1,57 @@
+# Queen Attack
+
+Given the position of two queens on a chess board, indicate whether or not they
+are positioned so that they can attack each other.
+
+In the game of chess, a queen can attack pieces which are on the same
+row, column, or diagonal.
+
+A chessboard can be represented by an 8 by 8 array.
+
+So if you're told the white queen is at (2, 3) and the black queen at
+(5, 6), then you'd know you've got a set-up like so:
+
+```text
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ _ _
+_ _ _ W _ _ _ _
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ B _
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ _ _
+```
+
+You'd also be able to answer whether the queens can attack each other.
+In this case, that answer would be yes, they can, because both pieces
+share a diagonal.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby queen_attack_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride queen_attack_test.rb
+
+
+## Source
+
+J Dalbey's Programming Practice problems [http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html](http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/queen-attack/queen_attack_test.rb
+++ b/exercises/queen-attack/queen_attack_test.rb
@@ -1,0 +1,102 @@
+require 'minitest/autorun'
+require_relative 'queen_attack'
+
+# Common test data version: 2.0.0 44a1e12
+class QueenAttackTest < Minitest::Test
+  def test_queen_with_a_valid_position
+    # skip
+    assert Queens.new(white: [2, 2])
+  end
+
+  def test_queen_must_have_positive_row
+    skip
+    assert_raises ArgumentError do
+      Queens.new(white: [-2, 2])
+    end
+  end
+
+  def test_queen_must_have_row_on_board
+    skip
+    assert_raises ArgumentError do
+      Queens.new(white: [8, 4])
+    end
+  end
+
+  def test_queen_must_have_positive_column
+    skip
+    assert_raises ArgumentError do
+      Queens.new(white: [2, -2])
+    end
+  end
+
+  def test_queen_must_have_column_on_board
+    skip
+    assert_raises ArgumentError do
+      Queens.new(white: [4, 8])
+    end
+  end
+
+  def test_can_not_attack
+    skip
+    queens = Queens.new(white: [2, 4], black: [6, 6])
+    refute queens.attack?
+  end
+
+  def test_can_attack_on_same_row
+    skip
+    queens = Queens.new(white: [2, 4], black: [2, 6])
+    assert queens.attack?
+  end
+
+  def test_can_attack_on_same_column
+    skip
+    queens = Queens.new(white: [4, 5], black: [2, 5])
+    assert queens.attack?
+  end
+
+  def test_can_attack_on_first_diagonal
+    skip
+    queens = Queens.new(white: [2, 2], black: [0, 4])
+    assert queens.attack?
+  end
+
+  def test_can_attack_on_second_diagonal
+    skip
+    queens = Queens.new(white: [2, 2], black: [3, 1])
+    assert queens.attack?
+  end
+
+  def test_can_attack_on_third_diagonal
+    skip
+    queens = Queens.new(white: [2, 2], black: [1, 1])
+    assert queens.attack?
+  end
+
+  def test_can_attack_on_fourth_diagonal
+    skip
+    queens = Queens.new(white: [2, 2], black: [5, 5])
+    assert queens.attack?
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 2, BookKeeping::VERSION
+  end
+end

--- a/exercises/rail-fence-cipher/README.md
+++ b/exercises/rail-fence-cipher/README.md
@@ -1,0 +1,89 @@
+# Rail Fence Cipher
+
+Implement encoding and decoding for the rail fence cipher.
+
+The Rail Fence cipher is a form of transposition cipher that gets its name from
+the way in which it's encoded. It was already used by the ancient Greeks.
+
+In the Rail Fence cipher, the message is written downwards on successive "rails"
+of an imaginary fence, then moving up when we get to the bottom (like a zig-zag).
+Finally the message is then read off in rows.
+
+For example, using three "rails" and the message "WE ARE DISCOVERED FLEE AT ONCE",
+the cipherer writes out:
+
+```text
+W . . . E . . . C . . . R . . . L . . . T . . . E
+. E . R . D . S . O . E . E . F . E . A . O . C .
+. . A . . . I . . . V . . . D . . . E . . . N . .
+```
+
+Then reads off:
+
+```text
+WECRLTEERDSOEEFEAOCAIVDEN
+```
+
+To decrypt a message you take the zig-zag shape and fill the ciphertext along the rows.
+
+```text
+? . . . ? . . . ? . . . ? . . . ? . . . ? . . . ?
+. ? . ? . ? . ? . ? . ? . ? . ? . ? . ? . ? . ? .
+. . ? . . . ? . . . ? . . . ? . . . ? . . . ? . .
+```
+
+The first row has seven spots that can be filled with "WECRLTE".
+
+```text
+W . . . E . . . C . . . R . . . L . . . T . . . E
+. ? . ? . ? . ? . ? . ? . ? . ? . ? . ? . ? . ? .
+. . ? . . . ? . . . ? . . . ? . . . ? . . . ? . .
+```
+
+Now the 2nd row takes "ERDSOEEFEAOC".
+
+```text
+W . . . E . . . C . . . R . . . L . . . T . . . E
+. E . R . D . S . O . E . E . F . E . A . O . C .
+. . ? . . . ? . . . ? . . . ? . . . ? . . . ? . .
+```
+
+Leaving "AIVDEN" for the last row.
+
+```text
+W . . . E . . . C . . . R . . . L . . . T . . . E
+. E . R . D . S . O . E . E . F . E . A . O . C .
+. . A . . . I . . . V . . . D . . . E . . . N . .
+```
+
+If you now read along the zig-zag shape you can read the original message.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby rail_fence_cipher_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride rail_fence_cipher_test.rb
+
+
+## Source
+
+Wikipedia [https://en.wikipedia.org/wiki/Transposition_cipher#Rail_Fence_cipher](https://en.wikipedia.org/wiki/Transposition_cipher#Rail_Fence_cipher)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/rail-fence-cipher/rail_fence_cipher_test.rb
+++ b/exercises/rail-fence-cipher/rail_fence_cipher_test.rb
@@ -1,0 +1,66 @@
+require 'minitest/autorun'
+require_relative 'rail_fence_cipher'
+
+# rubocop:enable all
+class RailFenceCipherTest < Minitest::Test
+  def test_encode_with_empty_string
+    assert_equal '', RailFenceCipher.encode('', 4)
+  end
+
+  def test_encode_with_one_rail
+    skip
+    assert_equal 'One rail, only one rail',
+                 RailFenceCipher.encode('One rail, only one rail', 1)
+  end
+
+  def test_encode_with_two_rails
+    skip
+    assert_equal 'XXXXXXXXXOOOOOOOOO',
+                 RailFenceCipher.encode('XOXOXOXOXOXOXOXOXO', 2)
+  end
+
+  def test_encode_with_three_rails
+    skip
+    assert_equal 'WECRLTEERDSOEEFEAOCAIVDEN',
+                 RailFenceCipher.encode('WEAREDISCOVEREDFLEEATONCE', 3)
+  end
+
+  def test_encode_with_ending_in_the_middle
+    skip
+    assert_equal 'ESXIEECSR', RailFenceCipher.encode('EXERCISES', 4)
+  end
+
+  def test_encode_with_less_letters_than_rails
+    skip
+    assert_equal 'More rails than letters',
+                 RailFenceCipher.encode('More rails than letters', 24)
+  end
+
+  def test_decode_with_empty_string
+    skip
+    assert_equal '', RailFenceCipher.decode('', 4)
+  end
+
+  def test_decode_with_one_rail
+    skip
+    assert_equal 'ABCDEFGHIJKLMNOP',
+                 RailFenceCipher.decode('ABCDEFGHIJKLMNOP', 1)
+  end
+
+  def test_decode_with_two_rails
+    skip
+    assert_equal 'XOXOXOXOXOXOXOXOXO',
+                 RailFenceCipher.decode('XXXXXXXXXOOOOOOOOO', 2)
+  end
+
+  def test_decode_with_three_rails
+    skip
+    assert_equal 'THEDEVILISINTHEDETAILS',
+                 RailFenceCipher.decode('TEITELHDVLSNHDTISEIIEA', 3)
+  end
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, RailFenceCipher::VERSION
+  end
+end

--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -1,0 +1,48 @@
+# Raindrops
+
+Convert a number to a string, the contents of which depend on the number's factors.
+
+- If the number has 3 as a factor, output 'Pling'.
+- If the number has 5 as a factor, output 'Plang'.
+- If the number has 7 as a factor, output 'Plong'.
+- If the number does not have 3, 5, or 7 as a factor,
+  just pass the number's digits straight through.
+
+## Examples
+
+- 28's factors are 1, 2, 4, **7**, 14, 28.
+  - In raindrop-speak, this would be a simple "Plong".
+- 30's factors are 1, 2, **3**, **5**, 6, 10, 15, 30.
+  - In raindrop-speak, this would be a "PlingPlang".
+- 34 has four factors: 1, 2, 17, and 34.
+  - In raindrop-speak, this would be "34".
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby raindrops_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride raindrops_test.rb
+
+
+## Source
+
+A variation on a famous interview question intended to weed out potential candidates. [http://jumpstartlab.com](http://jumpstartlab.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/raindrops/raindrops_test.rb
+++ b/exercises/raindrops/raindrops_test.rb
@@ -1,0 +1,117 @@
+require 'minitest/autorun'
+require_relative 'raindrops'
+
+# Common test data version: 1.0.0 9db5371
+class RaindropsTest < Minitest::Test
+  def test_the_sound_for_1_is_1
+    # skip
+    assert_equal "1", Raindrops.convert(1)
+  end
+
+  def test_the_sound_for_3_is_pling
+    skip
+    assert_equal "Pling", Raindrops.convert(3)
+  end
+
+  def test_the_sound_for_5_is_plang
+    skip
+    assert_equal "Plang", Raindrops.convert(5)
+  end
+
+  def test_the_sound_for_7_is_plong
+    skip
+    assert_equal "Plong", Raindrops.convert(7)
+  end
+
+  def test_the_sound_for_6_is_pling_as_it_has_a_factor_3
+    skip
+    assert_equal "Pling", Raindrops.convert(6)
+  end
+
+  def test_2_to_the_power_3_does_not_make_a_raindrop_sound_as_3_is_the_exponent_not_the_base
+    skip
+    assert_equal "8", Raindrops.convert(8)
+  end
+
+  def test_the_sound_for_9_is_pling_as_it_has_a_factor_3
+    skip
+    assert_equal "Pling", Raindrops.convert(9)
+  end
+
+  def test_the_sound_for_10_is_plang_as_it_has_a_factor_5
+    skip
+    assert_equal "Plang", Raindrops.convert(10)
+  end
+
+  def test_the_sound_for_14_is_plong_as_it_has_a_factor_of_7
+    skip
+    assert_equal "Plong", Raindrops.convert(14)
+  end
+
+  def test_the_sound_for_15_is_plingplang_as_it_has_factors_3_and_5
+    skip
+    assert_equal "PlingPlang", Raindrops.convert(15)
+  end
+
+  def test_the_sound_for_21_is_plingplong_as_it_has_factors_3_and_7
+    skip
+    assert_equal "PlingPlong", Raindrops.convert(21)
+  end
+
+  def test_the_sound_for_25_is_plang_as_it_has_a_factor_5
+    skip
+    assert_equal "Plang", Raindrops.convert(25)
+  end
+
+  def test_the_sound_for_27_is_pling_as_it_has_a_factor_3
+    skip
+    assert_equal "Pling", Raindrops.convert(27)
+  end
+
+  def test_the_sound_for_35_is_plangplong_as_it_has_factors_5_and_7
+    skip
+    assert_equal "PlangPlong", Raindrops.convert(35)
+  end
+
+  def test_the_sound_for_49_is_plong_as_it_has_a_factor_7
+    skip
+    assert_equal "Plong", Raindrops.convert(49)
+  end
+
+  def test_the_sound_for_52_is_52
+    skip
+    assert_equal "52", Raindrops.convert(52)
+  end
+
+  def test_the_sound_for_105_is_plingplangplong_as_it_has_factors_3_5_and_7
+    skip
+    assert_equal "PlingPlangPlong", Raindrops.convert(105)
+  end
+
+  def test_the_sound_for_3125_is_plang_as_it_has_a_factor_5
+    skip
+    assert_equal "Plang", Raindrops.convert(3125)
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 3, BookKeeping::VERSION
+  end
+end

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -1,0 +1,49 @@
+# RNA Transcription
+
+Given a DNA strand, return its RNA complement (per RNA transcription).
+
+Both DNA and RNA strands are a sequence of nucleotides.
+
+The four nucleotides found in DNA are adenine (**A**), cytosine (**C**),
+guanine (**G**) and thymine (**T**).
+
+The four nucleotides found in RNA are adenine (**A**), cytosine (**C**),
+guanine (**G**) and uracil (**U**).
+
+Given a DNA strand, its transcribed RNA strand is formed by replacing
+each nucleotide with its complement:
+
+* `G` -> `C`
+* `C` -> `G`
+* `T` -> `A`
+* `A` -> `U`
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby rna_transcription_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride rna_transcription_test.rb
+
+
+## Source
+
+Rosalind [http://rosalind.info/problems/rna](http://rosalind.info/problems/rna)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/rna-transcription/rna_transcription_test.rb
+++ b/exercises/rna-transcription/rna_transcription_test.rb
@@ -1,0 +1,67 @@
+require 'minitest/autorun'
+require_relative 'rna_transcription'
+
+# Common test data version: 1.0.1 cb1fd3a
+class RnaTranscriptionTest < Minitest::Test
+  def test_rna_complement_of_cytosine_is_guanine
+    # skip
+    assert_equal 'G', Complement.of_dna('C')
+  end
+
+  def test_rna_complement_of_guanine_is_cytosine
+    skip
+    assert_equal 'C', Complement.of_dna('G')
+  end
+
+  def test_rna_complement_of_thymine_is_adenine
+    skip
+    assert_equal 'A', Complement.of_dna('T')
+  end
+
+  def test_rna_complement_of_adenine_is_uracil
+    skip
+    assert_equal 'U', Complement.of_dna('A')
+  end
+
+  def test_rna_complement
+    skip
+    assert_equal 'UGCACCAGAAUU', Complement.of_dna('ACGTGGTCTTAA')
+  end
+
+  def test_correctly_handles_invalid_input_rna_instead_of_dna
+    skip
+    assert_equal '', Complement.of_dna('U')
+  end
+
+  def test_correctly_handles_completely_invalid_dna_input
+    skip
+    assert_equal '', Complement.of_dna('XXX')
+  end
+
+  def test_correctly_handles_partially_invalid_dna_input
+    skip
+    assert_equal '', Complement.of_dna('ACGTXXXCTTAA')
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 4, BookKeeping::VERSION
+  end
+end

--- a/exercises/robot-name/README.md
+++ b/exercises/robot-name/README.md
@@ -1,0 +1,55 @@
+# Robot Name
+
+Manage robot factory settings.
+
+When robots come off the factory floor, they have no name.
+
+The first time you boot them up, a random name is generated in the format
+of two uppercase letters followed by three digits, such as RX837 or BC811.
+
+Every once in a while we need to reset a robot to its factory settings,
+which means that their name gets wiped. The next time you ask, it will
+respond with a new random name.
+
+The names must be random: they should not follow a predictable sequence.
+Random names means a risk of collisions. Your solution must ensure that
+every existing robot has a unique name.
+
+
+In order to make this easier to test, your solution will need to implement a
+`Robot.forget` method that clears any shared state that might exist to track
+duplicate robot names.
+
+Bonus points if this method does not need to do anything for your solution.
+
+
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby robot_name_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride robot_name_test.rb
+
+
+## Source
+
+A debugging session with Paul Blackwell at gSchool. [http://gschool.it](http://gschool.it)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/robot-name/robot_name_test.rb
+++ b/exercises/robot-name/robot_name_test.rb
@@ -1,0 +1,94 @@
+require 'minitest/autorun'
+require_relative 'robot_name'
+
+class RobotTest < Minitest::Test
+  NAME_REGEXP = /^[A-Z]{2}\d{3}$/
+
+  def setup
+    Robot.forget
+  end
+
+  def test_can_create_a_robot
+    skip
+    refute_nil Robot.new
+  end
+
+  def test_has_name
+    skip
+    assert_match NAME_REGEXP, Robot.new.name
+  end
+
+  def test_name_sticks
+    skip
+    robot = Robot.new
+    original_name = robot.name
+    assert_equal original_name, robot.name
+  end
+
+  def test_reset_changes_name
+    skip
+    robot = Robot.new
+    original_name = robot.name
+    robot.reset
+    refute_equal original_name, robot.name
+  end
+
+  def test_reset_before_name_called_does_not_cause_an_error
+    skip
+    robot = Robot.new
+    robot.reset
+    assert_match NAME_REGEXP, Robot.new.name
+  end
+
+  def test_reset_multiple_times
+    skip
+    robot = Robot.new
+    names = []
+    5.times do
+      robot.reset
+      names << robot.name
+    end
+    # This will probably be 5, but name uniqueness is only a requirement
+    # accross multiple robots and consecutive calls to reset.
+    assert names.uniq.size > 1
+  end
+
+  def test_different_robots_have_different_names
+    skip
+    refute_equal Robot.new.name, Robot.new.name
+  end
+
+  # This test assumes you're using Kernel.rand as a source of randomness
+  def test_different_name_when_chosen_name_is_taken
+    skip
+    same_seed = 1234
+    Kernel.srand same_seed
+    robot_1 = Robot.new
+    name_1  = robot_1.name
+    Kernel.srand same_seed
+    robot_2 = Robot.new
+    name_2 = robot_2.name
+    refute_equal name_1, name_2
+  end
+
+  def test_generate_all_robots
+    skip
+    all_names_count = 26 * 26 * 1000
+    time_limit = Time.now + 60 # seconds
+    seen_names = Hash.new(0)
+    robots = []
+    while seen_names.size < all_names_count && Time.now < time_limit
+      robot = Robot.new
+      seen_names[robot.name] += 1
+      robots << robot
+    end
+    timeout_message = "Timed out trying to generate all possible robots"
+    assert_equal all_names_count, robots.size, timeout_message
+    assert seen_names.values.all? { |count| count == 1 }, "Some names used more than once"
+    assert seen_names.keys.all? { |name| name.match(NAME_REGEXP) }, "Not all names match #{NAME_REGEXP}"
+  end
+
+  def test_version
+    assert_equal 3, BookKeeping::VERSION
+  end
+end

--- a/exercises/robot-simulator/README.md
+++ b/exercises/robot-simulator/README.md
@@ -1,0 +1,58 @@
+# Robot Simulator
+
+Write a robot simulator.
+
+A robot factory's test facility needs a program to verify robot movements.
+
+The robots have three possible movements:
+
+- turn right
+- turn left
+- advance
+
+Robots are placed on a hypothetical infinite grid, facing a particular
+direction (north, east, south, or west) at a set of {x,y} coordinates,
+e.g., {3,8}, with coordinates increasing to the north and east.
+
+The robot then receives a number of instructions, at which point the
+testing facility verifies the robot's new position, and in which
+direction it is pointing.
+
+- The letter-string "RAALAL" means:
+  - Turn right
+  - Advance twice
+  - Turn left
+  - Advance once
+  - Turn left yet again
+- Say a robot starts at {7, 3} facing north. Then running this stream
+  of instructions should leave it at {9, 4} facing west.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby robot_simulator_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride robot_simulator_test.rb
+
+
+## Source
+
+Inspired by an interview question at a famous company.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/robot-simulator/robot_simulator_test.rb
+++ b/exercises/robot-simulator/robot_simulator_test.rb
@@ -1,0 +1,182 @@
+require 'minitest/autorun'
+require_relative 'robot_simulator'
+
+class RobotTurningTest < Minitest::Test
+  attr_reader :robot
+
+  def setup
+    @robot = Robot.new
+  end
+
+  def test_robot_bearing
+    [:east, :west, :north, :south].each do |direction|
+      robot.orient(direction)
+      assert_equal direction, robot.bearing
+    end
+  end
+
+  def test_invalid_robot_bearing
+    skip
+    assert_raises ArgumentError do
+      robot.orient(:crood)
+    end
+  end
+
+  def test_turn_right_from_north
+    skip
+    robot.orient(:north)
+    robot.turn_right
+    assert_equal :east, robot.bearing
+  end
+
+  def test_turn_right_from_east
+    skip
+    robot.orient(:east)
+    robot.turn_right
+    assert_equal :south, robot.bearing
+  end
+
+  def test_turn_right_from_south
+    skip
+    robot.orient(:south)
+    robot.turn_right
+    assert_equal :west, robot.bearing
+  end
+
+  def test_turn_right_from_west
+    skip
+    robot.orient(:west)
+    robot.turn_right
+    assert_equal :north, robot.bearing
+  end
+
+  def test_turn_left_from_north
+    skip
+    robot.orient(:north)
+    robot.turn_left
+    assert_equal :west, robot.bearing
+  end
+
+  def test_turn_left_from_east
+    skip
+    robot.orient(:east)
+    robot.turn_left
+    assert_equal :north, robot.bearing
+  end
+
+  def test_turn_left_from_south
+    skip
+    robot.orient(:south)
+    robot.turn_left
+    assert_equal :east, robot.bearing
+  end
+
+  def test_turn_left_from_west
+    skip
+    robot.orient(:west)
+    robot.turn_left
+    assert_equal :south, robot.bearing
+  end
+
+  def test_robot_coordinates
+    skip
+    robot.at(3, 0)
+    assert_equal [3, 0], robot.coordinates
+  end
+
+  def test_other_robot_coordinates
+    skip
+    robot.at(-2, 5)
+    assert_equal [-2, 5], robot.coordinates
+  end
+
+  def test_advance_when_facing_north
+    skip
+    robot.at(0, 0)
+    robot.orient(:north)
+    robot.advance
+    assert_equal [0, 1], robot.coordinates
+  end
+
+  def test_advance_when_facing_east
+    skip
+    robot.at(0, 0)
+    robot.orient(:east)
+    robot.advance
+    assert_equal [1, 0], robot.coordinates
+  end
+
+  def test_advance_when_facing_south
+    skip
+    robot.at(0, 0)
+    robot.orient(:south)
+    robot.advance
+    assert_equal [0, -1], robot.coordinates
+  end
+
+  def test_advance_when_facing_west
+    skip
+    robot.at(0, 0)
+    robot.orient(:west)
+    robot.advance
+    assert_equal [-1, 0], robot.coordinates
+  end
+end
+
+class RobotSimulatorTest < Minitest::Test
+  def simulator
+    @simulator ||= Simulator.new
+  end
+
+  def test_instructions_for_turning_left
+    skip
+    assert_equal [:turn_left], simulator.instructions('L')
+  end
+
+  def test_instructions_for_turning_right
+    skip
+    assert_equal [:turn_right], simulator.instructions('R')
+  end
+
+  def test_instructions_for_advancing
+    skip
+    assert_equal [:advance], simulator.instructions('A')
+  end
+
+  def test_series_of_instructions
+    skip
+    commands = [:turn_right, :advance, :advance, :turn_left]
+    assert_equal commands, simulator.instructions('RAAL')
+  end
+
+  def test_instruct_robot
+    skip
+    robot = Robot.new
+    simulator.place(robot, x: -2, y: 1, direction: :east)
+    simulator.evaluate(robot, 'RLAALAL')
+    assert_equal [0, 2], robot.coordinates
+    assert_equal :west, robot.bearing
+  end
+
+  def test_instruct_many_robots
+    skip
+    robot1 = Robot.new
+    robot2 = Robot.new
+    robot3 = Robot.new
+    simulator.place(robot1, x: 0, y: 0, direction: :north)
+    simulator.place(robot2, x: 2, y: -7, direction: :east)
+    simulator.place(robot3, x: 8, y: 4, direction: :south)
+    simulator.evaluate(robot1, 'LAAARALA')
+    simulator.evaluate(robot2, 'RRAAAAALA')
+    simulator.evaluate(robot3, 'LAAARRRALLLL')
+
+    assert_equal [-4, 1], robot1.coordinates
+    assert_equal :west, robot1.bearing
+
+    assert_equal [-3, -8], robot2.coordinates
+    assert_equal :south, robot2.bearing
+
+    assert_equal [11, 5], robot3.coordinates
+    assert_equal :north, robot3.bearing
+  end
+end

--- a/exercises/roman-numerals/README.md
+++ b/exercises/roman-numerals/README.md
@@ -1,0 +1,73 @@
+# Roman Numerals
+
+Write a function to convert from normal numbers to Roman Numerals.
+
+The Romans were a clever bunch. They conquered most of Europe and ruled
+it for hundreds of years. They invented concrete and straight roads and
+even bikinis. One thing they never discovered though was the number
+zero. This made writing and dating extensive histories of their exploits
+slightly more challenging, but the system of numbers they came up with
+is still in use today. For example the BBC uses Roman numerals to date
+their programmes.
+
+The Romans wrote numbers using letters - I, V, X, L, C, D, M. (notice
+these letters have lots of straight lines and are hence easy to hack
+into stone tablets).
+
+```text
+ 1  => I
+10  => X
+ 7  => VII
+```
+
+There is no need to be able to convert numbers larger than about 3000.
+(The Romans themselves didn't tend to go any higher)
+
+Wikipedia says: Modern Roman numerals ... are written by expressing each
+digit separately starting with the left most digit and skipping any
+digit with a value of zero.
+
+To see this in practice, consider the example of 1990.
+
+In Roman numerals 1990 is MCMXC:
+
+1000=M
+900=CM
+90=XC
+
+2008 is written as MMVIII:
+
+2000=MM
+8=VIII
+
+See also: http://www.novaroma.org/via_romana/numbers.html
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby roman_numerals_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride roman_numerals_test.rb
+
+
+## Source
+
+The Roman Numeral Kata [http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals](http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/roman-numerals/roman_numerals_test.rb
+++ b/exercises/roman-numerals/roman_numerals_test.rb
@@ -1,0 +1,117 @@
+require 'minitest/autorun'
+require_relative 'roman_numerals'
+
+# Common test data version: 1.0.0 070e8d5
+class RomanNumeralsTest < Minitest::Test
+  def test_1
+    # skip
+    assert_equal 'I', 1.to_roman
+  end
+
+  def test_2
+    skip
+    assert_equal 'II', 2.to_roman
+  end
+
+  def test_3
+    skip
+    assert_equal 'III', 3.to_roman
+  end
+
+  def test_4
+    skip
+    assert_equal 'IV', 4.to_roman
+  end
+
+  def test_5
+    skip
+    assert_equal 'V', 5.to_roman
+  end
+
+  def test_6
+    skip
+    assert_equal 'VI', 6.to_roman
+  end
+
+  def test_9
+    skip
+    assert_equal 'IX', 9.to_roman
+  end
+
+  def test_27
+    skip
+    assert_equal 'XXVII', 27.to_roman
+  end
+
+  def test_48
+    skip
+    assert_equal 'XLVIII', 48.to_roman
+  end
+
+  def test_59
+    skip
+    assert_equal 'LIX', 59.to_roman
+  end
+
+  def test_93
+    skip
+    assert_equal 'XCIII', 93.to_roman
+  end
+
+  def test_141
+    skip
+    assert_equal 'CXLI', 141.to_roman
+  end
+
+  def test_163
+    skip
+    assert_equal 'CLXIII', 163.to_roman
+  end
+
+  def test_402
+    skip
+    assert_equal 'CDII', 402.to_roman
+  end
+
+  def test_575
+    skip
+    assert_equal 'DLXXV', 575.to_roman
+  end
+
+  def test_911
+    skip
+    assert_equal 'CMXI', 911.to_roman
+  end
+
+  def test_1024
+    skip
+    assert_equal 'MXXIV', 1024.to_roman
+  end
+
+  def test_3000
+    skip
+    assert_equal 'MMM', 3000.to_roman
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 2, BookKeeping::VERSION
+  end
+end

--- a/exercises/rotational-cipher/README.md
+++ b/exercises/rotational-cipher/README.md
@@ -1,0 +1,61 @@
+# Rotational Cipher
+
+Create an implementation of the rotational cipher, also sometimes called the Caesar cipher.
+
+The Caesar cipher is a simple shift cipher that relies on
+transposing all the letters in the alphabet using an integer key
+between `0` and `26`. Using a key of `0` or `26` will always yield
+the same output due to modular arithmetic. The letter is shifted
+for as many values as the value of the key.
+
+The general notation for rotational ciphers is `ROT + <key>`.
+The most commonly used rotational cipher is `ROT13`.
+
+A `ROT13` on the Latin alphabet would be as follows:
+
+```text
+Plain:  abcdefghijklmnopqrstuvwxyz
+Cipher: nopqrstuvwxyzabcdefghijklm
+```
+
+It is stronger than the Atbash cipher because it has 27 possible keys, and 25 usable keys.
+
+Ciphertext is written out in the same formatting as the input including spaces and punctuation.
+
+## Examples
+
+- ROT5  `omg` gives `trl`
+- ROT0  `c` gives `c`
+- ROT26 `Cool` gives `Cool`
+- ROT13 `The quick brown fox jumps over the lazy dog.` gives `Gur dhvpx oebja sbk whzcf bire gur ynml qbt.`
+- ROT13 `Gur dhvpx oebja sbk whzcf bire gur ynml qbt.` gives `The quick brown fox jumps over the lazy dog.`
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby rotational_cipher_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride rotational_cipher_test.rb
+
+
+## Source
+
+Wikipedia [https://en.wikipedia.org/wiki/Caesar_cipher](https://en.wikipedia.org/wiki/Caesar_cipher)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/rotational-cipher/rotational_cipher_test.rb
+++ b/exercises/rotational-cipher/rotational_cipher_test.rb
@@ -1,0 +1,77 @@
+require 'minitest/autorun'
+require_relative 'rotational_cipher'
+
+# Common test data version: 1.1.0 9c658d1
+class RotationalCipherTest < Minitest::Test
+  def test_rotate_a_by_0_same_output_as_input
+    # skip
+    assert_equal "a", RotationalCipher.rotate("a", 0)
+  end
+
+  def test_rotate_a_by_1
+    skip
+    assert_equal "b", RotationalCipher.rotate("a", 1)
+  end
+
+  def test_rotate_a_by_26_same_output_as_input
+    skip
+    assert_equal "a", RotationalCipher.rotate("a", 26)
+  end
+
+  def test_rotate_m_by_13
+    skip
+    assert_equal "z", RotationalCipher.rotate("m", 13)
+  end
+
+  def test_rotate_n_by_13_with_wrap_around_alphabet
+    skip
+    assert_equal "a", RotationalCipher.rotate("n", 13)
+  end
+
+  def test_rotate_capital_letters
+    skip
+    assert_equal "TRL", RotationalCipher.rotate("OMG", 5)
+  end
+
+  def test_rotate_spaces
+    skip
+    assert_equal "T R L", RotationalCipher.rotate("O M G", 5)
+  end
+
+  def test_rotate_numbers
+    skip
+    assert_equal "Xiwxmrk 1 2 3 xiwxmrk", RotationalCipher.rotate("Testing 1 2 3 testing", 4)
+  end
+
+  def test_rotate_punctuation
+    skip
+    assert_equal "Gzo'n zvo, Bmviyhv!", RotationalCipher.rotate("Let's eat, Grandma!", 21)
+  end
+
+  def test_rotate_all_letters
+    skip
+    assert_equal "Gur dhvpx oebja sbk whzcf bire gur ynml qbt.", RotationalCipher.rotate("The quick brown fox jumps over the lazy dog.", 13)
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/run-length-encoding/README.md
+++ b/exercises/run-length-encoding/README.md
@@ -1,0 +1,54 @@
+# Run Length Encoding
+
+Implement run-length encoding and decoding.
+
+Run-length encoding (RLE) is a simple form of data compression, where runs
+(consecutive data elements) are replaced by just one data value and count.
+
+For example we can represent the original 53 characters with only 13.
+
+```text
+"WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB"  ->  "12WB12W3B24WB"
+```
+
+RLE allows the original data to be perfectly reconstructed from
+the compressed data, which makes it a lossless data compression.
+
+```text
+"AABCCCDEEEE"  ->  "2AB3CD4E"  ->  "AABCCCDEEEE"
+```
+
+For simplicity, you can assume that the unencoded string will only contain
+the letters A through Z (either lower or upper case) and whitespace. This way
+data to be encoded will never contain any numbers and numbers inside data to
+be decoded always represent the count for the following character.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby run_length_encoding_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride run_length_encoding_test.rb
+
+
+## Source
+
+Wikipedia [https://en.wikipedia.org/wiki/Run-length_encoding](https://en.wikipedia.org/wiki/Run-length_encoding)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/run-length-encoding/run_length_encoding_test.rb
+++ b/exercises/run-length-encoding/run_length_encoding_test.rb
@@ -1,0 +1,119 @@
+require 'minitest/autorun'
+require_relative 'run_length_encoding'
+
+# Common test data version: 1.0.0 503a57a
+class RunLengthEncodingTest < Minitest::Test
+  def test_encode_empty_string
+    # skip
+    input = ''
+    output = ''
+    assert_equal output, RunLengthEncoding.encode(input)
+  end
+
+  def test_encode_single_characters_only_are_encoded_without_count
+    skip
+    input = 'XYZ'
+    output = 'XYZ'
+    assert_equal output, RunLengthEncoding.encode(input)
+  end
+
+  def test_encode_string_with_no_single_characters
+    skip
+    input = 'AABBBCCCC'
+    output = '2A3B4C'
+    assert_equal output, RunLengthEncoding.encode(input)
+  end
+
+  def test_encode_single_characters_mixed_with_repeated_characters
+    skip
+    input = 'WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB'
+    output = '12WB12W3B24WB'
+    assert_equal output, RunLengthEncoding.encode(input)
+  end
+
+  def test_encode_multiple_whitespace_mixed_in_string
+    skip
+    input = '  hsqq qww  '
+    output = '2 hs2q q2w2 '
+    assert_equal output, RunLengthEncoding.encode(input)
+  end
+
+  def test_encode_lowercase_characters
+    skip
+    input = 'aabbbcccc'
+    output = '2a3b4c'
+    assert_equal output, RunLengthEncoding.encode(input)
+  end
+
+  def test_decode_empty_string
+    skip
+    input = ''
+    output = ''
+    assert_equal output, RunLengthEncoding.decode(input)
+  end
+
+  def test_decode_single_characters_only
+    skip
+    input = 'XYZ'
+    output = 'XYZ'
+    assert_equal output, RunLengthEncoding.decode(input)
+  end
+
+  def test_decode_string_with_no_single_characters
+    skip
+    input = '2A3B4C'
+    output = 'AABBBCCCC'
+    assert_equal output, RunLengthEncoding.decode(input)
+  end
+
+  def test_decode_single_characters_with_repeated_characters
+    skip
+    input = '12WB12W3B24WB'
+    output = 'WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB'
+    assert_equal output, RunLengthEncoding.decode(input)
+  end
+
+  def test_decode_multiple_whitespace_mixed_in_string
+    skip
+    input = '2 hs2q q2w2 '
+    output = '  hsqq qww  '
+    assert_equal output, RunLengthEncoding.decode(input)
+  end
+
+  def test_decode_lower_case_string
+    skip
+    input = '2a3b4c'
+    output = 'aabbbcccc'
+    assert_equal output, RunLengthEncoding.decode(input)
+  end
+
+  def test_consistency_encode_followed_by_decode_gives_original_string
+    skip
+    input = 'zzz ZZ  zZ'
+    output = 'zzz ZZ  zZ'
+    assert_equal output,
+                 RunLengthEncoding.decode(RunLengthEncoding.encode(input))
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 3, BookKeeping::VERSION
+  end
+end

--- a/exercises/saddle-points/README.md
+++ b/exercises/saddle-points/README.md
@@ -1,0 +1,57 @@
+# Saddle Points
+
+Detect saddle points in a matrix.
+
+So say you have a matrix like so:
+
+```text
+    0  1  2
+  |---------
+0 | 9  8  7
+1 | 5  3  2     <--- saddle point at (1,0)
+2 | 6  6  7
+```
+
+It has a saddle point at (1, 0).
+
+It's called a "saddle point" because it is greater than or equal to
+every element in its row and less than or equal to every element in
+its column.
+
+A matrix may have zero or more saddle points.
+
+Your code should be able to provide the (possibly empty) list of all the
+saddle points for any given matrix.
+
+Note that you may find other definitions of matrix saddle points online,
+but the tests for this exercise follow the above unambiguous definition.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby saddle_points_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride saddle_points_test.rb
+
+
+## Source
+
+J Dalbey's Programming Practice problems [http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html](http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/saddle-points/saddle_points_test.rb
+++ b/exercises/saddle-points/saddle_points_test.rb
@@ -1,0 +1,63 @@
+require 'minitest/autorun'
+require_relative 'saddle_points'
+
+class MatrixTest < Minitest::Test
+  def test_extract_a_row
+    matrix = Matrix.new("1 2\n10 20")
+    assert_equal [1, 2], matrix.rows[0]
+  end
+
+  def test_extract_same_row_again
+    skip
+    matrix = Matrix.new("9 7\n8 6")
+    assert_equal [9, 7], matrix.rows[0]
+  end
+
+  def test_extract_other_row
+    skip
+    matrix = Matrix.new("9 8 7\n19 18 17")
+    assert_equal [19, 18, 17], matrix.rows[1]
+  end
+
+  def test_extract_other_row_again
+    skip
+    matrix = Matrix.new("1 4 9\n16 25 36")
+    assert_equal [16, 25, 36], matrix.rows[1]
+  end
+
+  def test_extract_a_column
+    skip
+    matrix = Matrix.new("1 2 3\n4 5 6\n7 8 9\n 8 7 6")
+    assert_equal [1, 4, 7, 8], matrix.columns[0]
+  end
+
+  def test_extract_another_column
+    skip
+    matrix = Matrix.new("89 1903 3\n18 3 1\n9 4 800")
+    assert_equal [1903, 3, 4], matrix.columns[1]
+  end
+
+  def test_no_saddle_point
+    skip
+    matrix = Matrix.new("2 1\n1 2")
+    assert_equal [], matrix.saddle_points
+  end
+
+  def test_a_saddle_point
+    skip
+    matrix = Matrix.new("1 2\n3 4")
+    assert_equal [[0, 1]], matrix.saddle_points
+  end
+
+  def test_another_saddle_point
+    skip
+    matrix = Matrix.new("18 3 39 19 91\n38 10 8 77 320\n3 4 8 6 7")
+    assert_equal [[2, 2]], matrix.saddle_points
+  end
+
+  def test_multiple_saddle_points
+    skip
+    matrix = Matrix.new("4 5 4\n3 5 5\n1 5 4")
+    assert_equal [[0, 1], [1, 1], [2, 1]], matrix.saddle_points
+  end
+end

--- a/exercises/say/README.md
+++ b/exercises/say/README.md
@@ -1,0 +1,93 @@
+# Say
+
+Given a number from 0 to 999,999,999,999, spell out that number in English.
+
+## Step 1
+
+Handle the basic case of 0 through 99.
+
+If the input to the program is `22`, then the output should be
+`'twenty-two'`.
+
+Your program should complain loudly if given a number outside the
+blessed range.
+
+Some good test cases for this program are:
+
+- 0
+- 14
+- 50
+- 98
+- -1
+- 100
+
+### Extension
+
+If you're on a Mac, shell out to Mac OS X's `say` program to talk out
+loud.
+
+## Step 2
+
+Implement breaking a number up into chunks of thousands.
+
+So `1234567890` should yield a list like 1, 234, 567, and 890, while the
+far simpler `1000` should yield just 1 and 0.
+
+The program must also report any values that are out of range.
+
+## Step 3
+
+Now handle inserting the appropriate scale word between those chunks.
+
+So `1234567890` should yield `'1 billion 234 million 567 thousand 890'`
+
+The program must also report any values that are out of range.  It's
+fine to stop at "trillion".
+
+## Step 4
+
+Put it all together to get nothing but plain English.
+
+`12345` should give `twelve thousand three hundred forty-five`.
+
+The program must also report any values that are out of range.
+
+### Extensions
+
+Use _and_ (correctly) when spelling out the number in English:
+
+- 14 becomes "fourteen".
+- 100 becomes "one hundred".
+- 120 becomes "one hundred and twenty".
+- 1002 becomes "one thousand and two".
+- 1323 becomes "one thousand three hundred and twenty-three".
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby say_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride say_test.rb
+
+
+## Source
+
+A variation on JavaRanch CattleDrive, exercise 4a [http://www.javaranch.com/say.jsp](http://www.javaranch.com/say.jsp)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/say/say_test.rb
+++ b/exercises/say/say_test.rb
@@ -1,0 +1,121 @@
+require 'minitest/autorun'
+require_relative 'say'
+
+# Common test data version: 1.0.0 be403e1
+class SayTest < Minitest::Test
+  def test_zero
+    # skip
+    question = 0
+    assert_equal('zero', Say.new(question).in_english)
+  end
+
+  def test_one
+    skip
+    question = 1
+    assert_equal('one', Say.new(question).in_english)
+  end
+
+  def test_fourteen
+    skip
+    question = 14
+    assert_equal('fourteen', Say.new(question).in_english)
+  end
+
+  def test_twenty
+    skip
+    question = 20
+    assert_equal('twenty', Say.new(question).in_english)
+  end
+
+  def test_twenty_two
+    skip
+    question = 22
+    assert_equal('twenty-two', Say.new(question).in_english)
+  end
+
+  def test_one_hundred
+    skip
+    question = 100
+    assert_equal('one hundred', Say.new(question).in_english)
+  end
+
+  def test_one_hundred_twenty_three
+    skip
+    question = 123
+    assert_equal('one hundred twenty-three', Say.new(question).in_english)
+  end
+
+  def test_one_thousand
+    skip
+    question = 1_000
+    assert_equal('one thousand', Say.new(question).in_english)
+  end
+
+  def test_one_thousand_two_hundred_thirty_four
+    skip
+    question = 1_234
+    assert_equal('one thousand two hundred thirty-four', Say.new(question).in_english)
+  end
+
+  def test_one_million
+    skip
+    question = 1_000_000
+    assert_equal('one million', Say.new(question).in_english)
+  end
+
+  def test_one_million_two_thousand_three_hundred_forty_five
+    skip
+    question = 1_002_345
+    assert_equal('one million two thousand three hundred forty-five', Say.new(question).in_english)
+  end
+
+  def test_one_billion
+    skip
+    question = 1_000_000_000
+    assert_equal('one billion', Say.new(question).in_english)
+  end
+
+  def test_a_big_number
+    skip
+    question = 987_654_321_123
+    assert_equal('nine hundred eighty-seven billion six hundred fifty-four million three hundred twenty-one thousand one hundred twenty-three', Say.new(question).in_english)
+  end
+
+  def test_numbers_below_zero_are_out_of_range
+    skip
+    question = -1
+    assert_raises ArgumentError do
+      Say.new(question).in_english
+    end
+  end
+
+  def test_numbers_above_999999999999_are_out_of_range
+    skip
+    question = 1_000_000_000_000
+    assert_raises ArgumentError do
+      Say.new(question).in_english
+    end
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/scale-generator/README.md
+++ b/exercises/scale-generator/README.md
@@ -1,0 +1,82 @@
+# Scale Generator
+
+Given a tonic, or starting note, and a set of intervals, generate
+the musical scale starting with the tonic and following the
+specified interval pattern.
+
+Scales in Western music are based on the chromatic (12-note) scale.This
+scale can be expressed as the following group of pitches:
+
+A, A#, B, C, C#, D, D#, E, F, F#, G, G#
+
+A given sharp note (indicated by a #), can also be expressed as the flat
+of the note above it (indicated by a b), so the chromatic scale can also be
+written like this:
+
+A, Bb, B, C, Db, D, Eb, E, F, Gb, G, Ab
+
+The major and minor scale and modes are subsets of this twelve-pitch
+collection. They have seven pitches, and are called diatonic scales.
+The collection of notes in these scales is written with either sharps or
+flats, depending on the tonic. Here is a list of which are which:
+
+No Accidentals:
+C major
+A minor
+
+Use Sharps:
+G, D, A, E, B, F# major
+e, b, f#, c#, g#, d# minor
+
+Use Flats:
+F, Bb, Eb, Ab, Db, Gb major
+d, g, c, f, bb, eb minor
+
+The diatonic scales, and all other scales that derive from the
+chromatic scale, are built upon intervals. An interval is the space
+between two pitches.
+
+The simplest interval is between two adjacent notes, and is called a
+"half step", or "minor second" (sometimes written as a lower-case "m").
+The interval between two notes that have an interceding note is called
+a "whole step" or "major second" (written as an upper-case "M"). The
+diatonic scales are built using only these two intervals between
+adjacent notes.
+
+Non-diatonic scales can contain the same letter twice, and can contain other intervals.
+Sometimes they may be smaller than usual (diminished, written "D"), or larger
+(augmented, written "A").  Intervals larger than an augmented second have other names.
+
+Here is a table of pitches with the names of their interval distance from the tonic (A).
+
+|   A    |    A#   |    B    |    C    |    C#   |    D    |    D#   |    E    |    F    |    F#   |    G    |    G#   |    A   |
+|:------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|:-------:|:------:|
+| Unison | Min 2nd | Maj 2nd | Min 3rd | Maj 3rd | Per 4th | Tritone | Per 5th | Min 6th | Maj 6th | Min 7th | Maj 7th | Octave |
+|        |         | Dim 3rd | Aug 2nd | Dim 4th |         | Aug 4th | Dim 5th | Aug 5th | Dim 7th | Aug 6th | Dim 8ve |        |
+|        |         |         |         |         |         | Dim 5th |         |         |         |         |         |        |
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby scale_generator_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride scale_generator_test.rb
+
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/scale-generator/scale_generator_test.rb
+++ b/exercises/scale-generator/scale_generator_test.rb
@@ -1,0 +1,169 @@
+require 'minitest/autorun'
+require_relative 'scale_generator'
+
+class ScaleGeneratorTest < Minitest::Test
+  def test_naming_scale
+    chromatic = Scale.new('c', :chromatic)
+    expected = 'C chromatic'
+    actual = chromatic.name
+    assert_equal expected, actual
+  end
+
+  def test_chromatic_scale
+    skip
+    chromatic = Scale.new('C', :chromatic)
+    expected = %w(C C# D D# E F F# G G# A A# B)
+    actual = chromatic.pitches
+    assert_equal expected, actual
+  end
+
+  def test_another_chromatic_scale
+    skip
+    chromatic = Scale.new('F', :chromatic)
+    expected = %w(F Gb G Ab A Bb B C Db D Eb E)
+    actual = chromatic.pitches
+    assert_equal expected, actual
+  end
+
+  def test_naming_major_scale
+    skip
+    major = Scale.new('G', :major, 'MMmMMMm')
+    expected = 'G major'
+    actual = major.name
+    assert_equal expected, actual
+  end
+
+  def test_major_scale
+    skip
+    major = Scale.new('C', :major, 'MMmMMMm')
+    expected = %w(C D E F G A B)
+    actual = major.pitches
+    assert_equal expected, actual
+  end
+
+  def test_another_major_scale
+    skip
+    major = Scale.new('G', :major, 'MMmMMMm')
+    expected = %w(G A B C D E F#)
+    actual = major.pitches
+    assert_equal expected, actual
+  end
+
+  def test_minor_scale
+    skip
+    minor = Scale.new('f#', :minor, 'MmMMmMM')
+    expected = %w(F# G# A B C# D E)
+    actual = minor.pitches
+    assert_equal expected, actual
+  end
+
+  def test_another_minor_scale
+    skip
+    minor = Scale.new('bb', :minor, 'MmMMmMM')
+    expected = %w(Bb C Db Eb F Gb Ab)
+    actual = minor.pitches
+    assert_equal expected, actual
+  end
+
+  def test_dorian_mode
+    skip
+    dorian = Scale.new('d', :dorian, 'MmMMMmM')
+    expected = %w(D E F G A B C)
+    actual = dorian.pitches
+    assert_equal expected, actual
+  end
+
+  def test_mixolydian_mode
+    skip
+    mixolydian = Scale.new('Eb', :mixolydian, 'MMmMMmM')
+    expected = %w(Eb F G Ab Bb C Db)
+    actual = mixolydian.pitches
+    assert_equal expected, actual
+  end
+
+  def test_lydian_mode
+    skip
+    lydian = Scale.new('a', :lydian, 'MMMmMMm')
+    expected = %w(A B C# D# E F# G#)
+    actual = lydian.pitches
+    assert_equal expected, actual
+  end
+
+  def test_phrygian_mode
+    skip
+    phrygian = Scale.new('e', :phrygian, 'mMMMmMM')
+    expected = %w(E F G A B C D)
+    actual = phrygian.pitches
+    assert_equal expected, actual
+  end
+
+  def test_locrian_mode
+    skip
+    locrian = Scale.new('g', :locrian, 'mMMmMMM')
+    expected = %w(G Ab Bb C Db Eb F)
+    actual = locrian.pitches
+    assert_equal expected, actual
+  end
+
+  def test_harmonic_minor
+    skip
+    harmonic_minor = Scale.new('d', :harmonic_minor, 'MmMMmAm')
+    expected = %w(D E F G A Bb Db)
+    actual = harmonic_minor.pitches
+    assert_equal expected, actual
+  end
+
+  def test_octatonic
+    skip
+    octatonic = Scale.new('C', :octatonic, 'MmMmMmMm')
+    expected = %w(C D D# F F# G# A B)
+    actual = octatonic.pitches
+    assert_equal expected, actual
+  end
+
+  def test_hexatonic
+    skip
+    hexatonic = Scale.new('Db', :hexatonic, 'MMMMMM')
+    expected = %w(Db Eb F G A B)
+    actual = hexatonic.pitches
+    assert_equal expected, actual
+  end
+
+  def test_pentatonic
+    skip
+    pentatonic = Scale.new('A', :pentatonic, 'MMAMA')
+    expected = %w(A B C# E F#)
+    actual = pentatonic.pitches
+    assert_equal expected, actual
+  end
+
+  def test_enigmatic
+    skip
+    enigmatic = Scale.new('G', :enigma, 'mAMMMmM')
+    expected = %w(G G# B C# D# F F#)
+    actual = enigmatic.pitches
+    assert_equal expected, actual
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/scrabble-score/README.md
+++ b/exercises/scrabble-score/README.md
@@ -1,0 +1,70 @@
+# Scrabble Score
+
+Given a word, compute the scrabble score for that word.
+
+## Letter Values
+
+You'll need these:
+
+```text
+Letter                           Value
+A, E, I, O, U, L, N, R, S, T       1
+D, G                               2
+B, C, M, P                         3
+F, H, V, W, Y                      4
+K                                  5
+J, X                               8
+Q, Z                               10
+```
+
+## Examples
+
+"cabbage" should be scored as worth 14 points:
+
+- 3 points for C
+- 1 point for A, twice
+- 3 points for B, twice
+- 2 points for G
+- 1 point for E
+
+And to total:
+
+- `3 + 2*1 + 2*3 + 2 + 1`
+- = `3 + 2 + 6 + 3`
+- = `5 + 9`
+- = 14
+
+## Extensions
+
+- You can play a double or a triple letter.
+- You can play a double or a triple word.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby scrabble_score_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride scrabble_score_test.rb
+
+
+## Source
+
+Inspired by the Extreme Startup game [https://github.com/rchatley/extreme_startup](https://github.com/rchatley/extreme_startup)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/scrabble-score/scrabble_score_test.rb
+++ b/exercises/scrabble-score/scrabble_score_test.rb
@@ -1,0 +1,48 @@
+require 'minitest/autorun'
+require_relative 'scrabble_score'
+
+class ScrabbleTest < Minitest::Test
+  def test_empty_word_scores_zero
+    assert_equal 0, Scrabble.new('').score
+  end
+
+  def test_whitespace_scores_zero
+    skip
+    assert_equal 0, Scrabble.new(" \t\n").score
+  end
+
+  def test_nil_scores_zero
+    skip
+    assert_equal 0, Scrabble.new(nil).score
+  end
+
+  def test_scores_very_short_word
+    skip
+    assert_equal 1, Scrabble.new('a').score
+  end
+
+  def test_scores_other_very_short_word
+    skip
+    assert_equal 4, Scrabble.new('f').score
+  end
+
+  def test_simple_word_scores_the_number_of_letters
+    skip
+    assert_equal 6, Scrabble.new('street').score
+  end
+
+  def test_complicated_word_scores_more
+    skip
+    assert_equal 22, Scrabble.new('quirky').score
+  end
+
+  def test_scores_are_case_insensitive
+    skip
+    assert_equal 41, Scrabble.new('OXYPHENBUTAZONE').score
+  end
+
+  def test_convenient_scoring
+    skip
+    assert_equal 13, Scrabble.score('alacrity')
+  end
+end

--- a/exercises/secret-handshake/README.md
+++ b/exercises/secret-handshake/README.md
@@ -1,0 +1,59 @@
+# Secret Handshake
+
+> There are 10 types of people in the world: Those who understand
+> binary, and those who don't.
+
+You and your fellow cohort of those in the "know" when it comes to
+binary decide to come up with a secret "handshake".
+
+```text
+1 = wink
+10 = double blink
+100 = close your eyes
+1000 = jump
+
+
+10000 = Reverse the order of the operations in the secret handshake.
+```
+
+Given a decimal number, convert it to the appropriate sequence of events for a secret handshake.
+
+Here's a couple of examples:
+
+Given the input 3, the function would return the array
+["wink", "double blink"] because 3 is 11 in binary.
+
+Given the input 19, the function would return the array
+["double blink", "wink"] because 19 is 10011 in binary.
+Notice that the addition of 16 (10000 in binary)
+has caused the array to be reversed.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby secret_handshake_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride secret_handshake_test.rb
+
+
+## Source
+
+Bert, in Mary Poppins [http://www.imdb.com/title/tt0058331/quotes/qt0437047](http://www.imdb.com/title/tt0058331/quotes/qt0437047)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/secret-handshake/secret_handshake_test.rb
+++ b/exercises/secret-handshake/secret_handshake_test.rb
@@ -1,0 +1,52 @@
+require 'minitest/autorun'
+require_relative 'secret_handshake'
+
+class SecretHandshakeTest < Minitest::Test
+  def test_handshake_1_to_wink
+    handshake = SecretHandshake.new(1)
+    assert_equal ['wink'], handshake.commands
+  end
+
+  def test_handshake_10_to_double_blink
+    skip
+    handshake = SecretHandshake.new(2)
+    assert_equal ['double blink'], handshake.commands
+  end
+
+  def test_handshake_100_to_close_your_eyes
+    skip
+    handshake = SecretHandshake.new(4)
+    assert_equal ['close your eyes'], handshake.commands
+  end
+
+  def test_handshake_1000_to_jump
+    skip
+    handshake = SecretHandshake.new(8)
+    assert_equal ['jump'], handshake.commands
+  end
+
+  def test_handshake_11_to_wink_and_double_blink
+    skip
+    handshake = SecretHandshake.new(3)
+    assert_equal ['wink', 'double blink'], handshake.commands
+  end
+
+  def test_handshake_10011_to_double_blink_and_wink
+    skip
+    handshake = SecretHandshake.new(19)
+    assert_equal ['double blink', 'wink'], handshake.commands
+  end
+
+  def test_handshake_11111_to_double_blink_and_wink
+    skip
+    handshake = SecretHandshake.new(31)
+    expected = ['jump', 'close your eyes', 'double blink', 'wink']
+    assert_equal expected, handshake.commands
+  end
+
+  def test_invalid_handshake
+    skip
+    handshake = SecretHandshake.new('piggies')
+    assert_equal [], handshake.commands
+  end
+end

--- a/exercises/series/README.md
+++ b/exercises/series/README.md
@@ -1,0 +1,51 @@
+# Series
+
+Given a string of digits, output all the contiguous substrings of length `n` in
+that string.
+
+For example, the string "49142" has the following 3-digit series:
+
+- 491
+- 914
+- 142
+
+And the following 4-digit series:
+
+- 4914
+- 9142
+
+And if you ask for a 6-digit series from a 5-digit string, you deserve
+whatever you get.
+
+Note that these series are only required to occupy *adjacent positions*
+in the input; the digits need not be *numerically consecutive*.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby series_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride series_test.rb
+
+
+## Source
+
+A subset of the Problem 8 at Project Euler [http://projecteuler.net/problem=8](http://projecteuler.net/problem=8)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/series/series_test.rb
+++ b/exercises/series/series_test.rb
@@ -1,0 +1,102 @@
+require 'minitest/autorun'
+require_relative 'series'
+
+class SeriesTest < Minitest::Test
+  def test_simple_slices_of_one
+    series = Series.new('01234')
+    assert_equal ['0', '1', '2', '3', '4'], series.slices(1)
+  end
+
+  def test_simple_slices_of_one_again
+    skip
+    series = Series.new('92834')
+    assert_equal ['9', '2', '8', '3', '4'], series.slices(1)
+  end
+
+  def test_simple_slices_of_two
+    skip
+    series = Series.new('01234')
+    assert_equal ['01', '12', '23', '34'], series.slices(2)
+  end
+
+  def test_other_slices_of_two
+    skip
+    series = Series.new('98273463')
+    expected = ['98', '82', '27', '73', '34', '46', '63']
+    assert_equal expected, series.slices(2)
+  end
+
+  def test_simple_slices_of_two_again
+    skip
+    series = Series.new('37103')
+    assert_equal ['37', '71', '10', '03'], series.slices(2)
+  end
+
+  def test_simple_slices_of_three
+    skip
+    series = Series.new('01234')
+    assert_equal ['012', '123', '234'], series.slices(3)
+  end
+
+  def test_simple_slices_of_three_again
+    skip
+    series = Series.new('31001')
+    assert_equal ['310', '100', '001'], series.slices(3)
+  end
+
+  def test_other_slices_of_three
+    skip
+    series = Series.new('982347')
+    expected = ['982', '823', '234', '347']
+    assert_equal expected, series.slices(3)
+  end
+
+  def test_simple_slices_of_four
+    skip
+    series = Series.new('01234')
+    assert_equal ['0123', '1234'], series.slices(4)
+  end
+
+  def test_simple_slices_of_four_again
+    skip
+    series = Series.new('91274')
+    assert_equal ['9127', '1274'], series.slices(4)
+  end
+
+  def test_simple_slices_of_five
+    skip
+    series = Series.new('01234')
+    assert_equal ['01234'], series.slices(5)
+  end
+
+  def test_simple_slices_of_five_again
+    skip
+    series = Series.new('81228')
+    assert_equal ['81228'], series.slices(5)
+  end
+
+  def test_simple_slice_that_blows_up
+    skip
+    series = Series.new('01234')
+    assert_raises ArgumentError do
+      series.slices(6)
+    end
+  end
+
+  def test_more_complicated_slice_that_blows_up
+    skip
+    slice_string = '01032987583'
+
+    series = Series.new(slice_string)
+    assert_raises ArgumentError do
+      series.slices(slice_string.length + 1)
+    end
+  end
+
+  def test_sequential_slices
+    skip
+    series = Series.new('1234')
+    assert_equal ['12', '23', '34'], series.slices(2)
+    assert_equal ['123', '234'], series.slices(3)
+  end
+end

--- a/exercises/sieve/README.md
+++ b/exercises/sieve/README.md
@@ -1,0 +1,58 @@
+# Sieve
+
+Use the Sieve of Eratosthenes to find all the primes from 2 up to a given
+number.
+
+The Sieve of Eratosthenes is a simple, ancient algorithm for finding all
+prime numbers up to any given limit. It does so by iteratively marking as
+composite (i.e. not prime) the multiples of each prime,
+starting with the multiples of 2.
+
+Create your range, starting at two and continuing up to and including the given limit. (i.e. [2, limit])
+
+The algorithm consists of repeating the following over and over:
+
+- take the next available unmarked number in your list (it is prime)
+- mark all the multiples of that number (they are not prime)
+
+Repeat until you have processed each number in your range.
+
+When the algorithm terminates, all the numbers in the list that have not
+been marked are prime.
+
+The wikipedia article has a useful graphic that explains the algorithm:
+https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes
+
+Notice that this is a very specific algorithm, and the tests don't check
+that you've implemented the algorithm, only that you've come up with the
+correct list of primes.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby sieve_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride sieve_test.rb
+
+
+## Source
+
+Sieve of Eratosthenes at Wikipedia [http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes](http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/sieve/sieve_test.rb
+++ b/exercises/sieve/sieve_test.rb
@@ -1,0 +1,68 @@
+require 'minitest/autorun'
+require_relative 'sieve'
+
+# Common test data version: 1.0.0 f2b2693
+class SieveTest < Minitest::Test
+  def test_no_primes_under_two
+    # skip
+    expected = []
+    assert_equal expected, Sieve.new(1).primes
+  end
+
+  def test_find_first_prime
+    skip
+    expected = [2]
+    assert_equal expected, Sieve.new(2).primes
+  end
+
+  def test_find_primes_up_to_10
+    skip
+    expected = [2, 3, 5, 7]
+    assert_equal expected, Sieve.new(10).primes
+  end
+
+  def test_limit_is_prime
+    skip
+    expected = [2, 3, 5, 7, 11, 13]
+    assert_equal expected, Sieve.new(13).primes
+  end
+
+  def test_find_primes_up_to_1000
+    skip
+    expected = [
+      2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59,
+      61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137, 139,
+      149, 151, 157, 163, 167, 173, 179, 181, 191, 193, 197, 199, 211, 223, 227, 229, 233,
+      239, 241, 251, 257, 263, 269, 271, 277, 281, 283, 293, 307, 311, 313, 317, 331, 337,
+      347, 349, 353, 359, 367, 373, 379, 383, 389, 397, 401, 409, 419, 421, 431, 433, 439,
+      443, 449, 457, 461, 463, 467, 479, 487, 491, 499, 503, 509, 521, 523, 541, 547, 557,
+      563, 569, 571, 577, 587, 593, 599, 601, 607, 613, 617, 619, 631, 641, 643, 647, 653,
+      659, 661, 673, 677, 683, 691, 701, 709, 719, 727, 733, 739, 743, 751, 757, 761, 769,
+      773, 787, 797, 809, 811, 821, 823, 827, 829, 839, 853, 857, 859, 863, 877, 881, 883,
+      887, 907, 911, 919, 929, 937, 941, 947, 953, 967, 971, 977, 983, 991, 997
+    ]
+    assert_equal expected, Sieve.new(1000).primes
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/simple-cipher/README.md
+++ b/exercises/simple-cipher/README.md
@@ -1,0 +1,112 @@
+# Simple Cipher
+
+Implement a simple shift cipher like Caesar and a more secure substitution cipher.
+
+## Step 1
+
+"If he had anything confidential to say, he wrote it in cipher, that is,
+by so changing the order of the letters of the alphabet, that not a word
+could be made out. If anyone wishes to decipher these, and get at their
+meaning, he must substitute the fourth letter of the alphabet, namely D,
+for A, and so with the others."
+—Suetonius, Life of Julius Caesar
+
+Ciphers are very straight-forward algorithms that allow us to render
+text less readable while still allowing easy deciphering. They are
+vulnerable to many forms of cryptoanalysis, but we are lucky that
+generally our little sisters are not cryptoanalysts.
+
+The Caesar Cipher was used for some messages from Julius Caesar that
+were sent afield. Now Caesar knew that the cipher wasn't very good, but
+he had one ally in that respect: almost nobody could read well. So even
+being a couple letters off was sufficient so that people couldn't
+recognize the few words that they did know.
+
+Your task is to create a simple shift cipher like the Caesar Cipher.
+This image is a great example of the Caesar Cipher:
+
+![Caesar Cipher][1]
+
+For example:
+
+Giving "iamapandabear" as input to the encode function returns the cipher "ldpdsdqgdehdu". Obscure enough to keep our message secret in transit.
+
+When "ldpdsdqgdehdu" is put into the decode function it would return
+the original "iamapandabear" letting your friend read your original
+message.
+
+## Step 2
+
+Shift ciphers are no fun though when your kid sister figures it out. Try
+amending the code to allow us to specify a key and use that for the
+shift distance. This is called a substitution cipher.
+
+Here's an example:
+
+Given the key "aaaaaaaaaaaaaaaaaa", encoding the string "iamapandabear"
+would return the original "iamapandabear".
+
+Given the key "ddddddddddddddddd", encoding our string "iamapandabear"
+would return the obscured "ldpdsdqgdehdu"
+
+In the example above, we've set a = 0 for the key value. So when the
+plaintext is added to the key, we end up with the same message coming
+out. So "aaaa" is not an ideal key. But if we set the key to "dddd", we
+would get the same thing as the Caesar Cipher.
+
+## Step 3
+
+The weakest link in any cipher is the human being. Let's make your
+substitution cipher a little more fault tolerant by providing a source
+of randomness and ensuring that the key contains only lowercase letters.
+
+If someone doesn't submit a key at all, generate a truly random key of
+at least 100 characters in length.
+
+If the key submitted is not composed only of lowercase letters, your
+solution should handle the error in a language-appropriate way.
+
+## Extensions
+
+Shift ciphers work by making the text slightly odd, but are vulnerable
+to frequency analysis. Substitution ciphers help that, but are still
+very vulnerable when the key is short or if spaces are preserved. Later
+on you'll see one solution to this problem in the exercise
+"crypto-square".
+
+If you want to go farther in this field, the questions begin to be about
+how we can exchange keys in a secure way. Take a look at [Diffie-Hellman
+on Wikipedia][dh] for one of the first implementations of this scheme.
+
+[1]: https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Caesar_cipher_left_shift_of_3.svg/320px-Caesar_cipher_left_shift_of_3.svg.png
+[dh]: http://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby simple_cipher_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride simple_cipher_test.rb
+
+
+## Source
+
+Substitution Cipher at Wikipedia [http://en.wikipedia.org/wiki/Substitution_cipher](http://en.wikipedia.org/wiki/Substitution_cipher)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/simple-cipher/simple_cipher_test.rb
+++ b/exercises/simple-cipher/simple_cipher_test.rb
@@ -1,0 +1,128 @@
+require 'minitest/autorun'
+require_relative 'simple_cipher'
+
+class RandomKeyCipherTest < Minitest::Test
+  def setup
+    @cipher = Cipher.new
+  end
+
+  def test_cipher_key_is_letters
+    assert_match(/\A[a-z]+\z/, @cipher.key)
+  end
+
+  # Here we take advantage of the fact that plaintext of "aaa..." doesn't
+  # outputs the key. This is a critical problem with shift ciphers, some
+  # characters will always output the key verbatim.
+  def test_cipher_encode
+    skip
+    plaintext = 'aaaaaaaaaa'
+    assert_equal(@cipher.key[0, 10], @cipher.encode(plaintext))
+  end
+
+  def test_cipher_decode
+    skip
+    plaintext = 'aaaaaaaaaa'
+    assert_equal(plaintext, @cipher.decode(@cipher.key[0, 10]))
+  end
+
+  def test_cipher_reversible
+    skip
+    plaintext = 'abcdefghij'
+    assert_equal(plaintext, @cipher.decode(@cipher.encode(plaintext)))
+  end
+end
+
+class IncorrectKeyCipherTest < Minitest::Test
+  def test_cipher_with_caps_key
+    skip
+    assert_raises ArgumentError do
+      Cipher.new('ABCDEF')
+    end
+  end
+
+  def test_cipher_with_numeric_key
+    skip
+    assert_raises ArgumentError do
+      Cipher.new('12345')
+    end
+  end
+
+  def test_cipher_with_empty_key
+    skip
+    assert_raises ArgumentError do
+      Cipher.new('')
+    end
+  end
+end
+
+class SubstitutionCipherTest < Minitest::Test
+  def setup
+    @key = 'abcdefghij'
+    @cipher = Cipher.new(@key)
+  end
+
+  def test_cipher_key_is_as_submitted
+    skip
+    assert_equal(@cipher.key, @key)
+  end
+
+  def test_cipher_encode
+    skip
+    plaintext = 'aaaaaaaaaa'
+    ciphertext = 'abcdefghij'
+    assert_equal(ciphertext, @cipher.encode(plaintext))
+  end
+
+  def test_cipher_decode
+    skip
+    plaintext = 'aaaaaaaaaa'
+    ciphertext = 'abcdefghij'
+    assert_equal(plaintext, @cipher.decode(ciphertext))
+  end
+
+  def test_cipher_reversible
+    skip
+    plaintext = 'abcdefghij'
+    assert_equal(plaintext, @cipher.decode(@cipher.encode(plaintext)))
+  end
+
+  def test_double_shift_encode
+    skip
+    plaintext = 'iamapandabear'
+    ciphertext = 'qayaeaagaciai'
+    assert_equal(ciphertext, Cipher.new('iamapandabear').encode(plaintext))
+  end
+
+  def test_cipher_encode_wrap
+    skip
+    plaintext = 'zzzzzzzzzz'
+    ciphertext = 'zabcdefghi'
+    assert_equal(ciphertext, @cipher.encode(plaintext))
+  end
+end
+
+class PseudoShiftCipherTest < Minitest::Test
+  def setup
+    @cipher = Cipher.new('dddddddddd')
+  end
+
+  def test_cipher_encode
+    skip
+    plaintext = 'aaaaaaaaaa'
+    ciphertext = 'dddddddddd'
+    assert_equal(ciphertext, @cipher.encode(plaintext))
+  end
+
+  def test_cipher_decode
+    skip
+    plaintext = 'aaaaaaaaaa'
+    ciphertext = 'dddddddddd'
+    assert_equal(plaintext, @cipher.decode(ciphertext))
+  end
+
+  def test_cipher_reversible
+    skip
+    plaintext = 'abcdefghij'
+    assert_equal(plaintext, @cipher.decode(@cipher.encode(plaintext)))
+  end
+end

--- a/exercises/simple-linked-list/README.md
+++ b/exercises/simple-linked-list/README.md
@@ -1,0 +1,52 @@
+# Simple Linked List
+
+Write a simple linked list implementation that uses Elements and a List.
+
+The linked list is a fundamental data structure in computer science,
+often used in the implementation of other data structures. They're
+pervasive in functional programming languages, such as Clojure, Erlang,
+or Haskell, but far less common in imperative languages such as Ruby or
+Python.
+
+The simplest kind of linked list is a singly linked list. Each element in the
+list contains data and a "next" field pointing to the next element in the list
+of elements.
+
+This variant of linked lists is often used to represent sequences or
+push-down stacks (also called a LIFO stack; Last In, First Out).
+
+As a first take, lets create a singly linked list to contain the range (1..10),
+and provide functions to reverse a linked list and convert to and from arrays.
+
+When implementing this in a language with built-in linked lists,
+implement your own abstract data type.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby simple_linked_list_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride simple_linked_list_test.rb
+
+
+## Source
+
+Inspired by 'Data Structures and Algorithms with Object-Oriented Design Patterns in Ruby', singly linked-lists. [http://www.brpreiss.com/books/opus8/html/page96.html#SECTION004300000000000000000](http://www.brpreiss.com/books/opus8/html/page96.html#SECTION004300000000000000000)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/simple-linked-list/simple_linked_list_test.rb
+++ b/exercises/simple-linked-list/simple_linked_list_test.rb
@@ -1,0 +1,163 @@
+require 'minitest/autorun'
+require_relative 'simple_linked_list'
+
+class LinkedListTest < Minitest::Test
+  def test_element
+    element = Element.new(1)
+    assert_equal 1, element.datum
+  end
+
+  def test_element_can_hold_a_different_value
+    skip
+    element = Element.new(10)
+    assert_equal 10, element.datum
+  end
+
+  def test_element_next
+    skip
+    element = Element.new(1)
+    assert_nil element.next
+  end
+
+  def test_element_next_can_be_assigned_to
+    skip
+    first  = Element.new(1)
+    second = Element.new(2)
+    first.next = second
+    assert_equal second, first.next
+  end
+
+  def test_list_push
+    skip
+    list = SimpleLinkedList.new
+    element = Element.new(1)
+    assert_equal list, list.push(element)
+  end
+
+  def test_list_pop
+    skip
+    list = SimpleLinkedList.new
+    element = Element.new(1)
+    list.push(element)
+    assert_equal element, list.pop
+  end
+
+  def test_list_pop_empty
+    skip
+    list = SimpleLinkedList.new
+    assert_nil list.pop
+  end
+
+  def test_list_pop_is_last_in_first_out
+    skip
+    list = SimpleLinkedList.new
+    first = Element.new(1)
+    second = Element.new(2)
+    list.push(first).push(second)
+    assert_equal second, list.pop
+  end
+
+  def test_list_empty_to_array
+    skip
+    list = SimpleLinkedList.new
+    assert_equal [], list.to_a
+  end
+
+  def test_list_single_to_array
+    skip
+    list = SimpleLinkedList.new
+    first = Element.new(1)
+    list.push(first)
+    assert_equal [1], list.to_a
+  end
+
+  def test_list_multiple_to_array
+    skip
+    list = SimpleLinkedList.new
+    first = Element.new(1)
+    second = Element.new(2)
+    third = Element.new(3)
+    list.push(first).push(second).push(third)
+    assert_equal [3, 2, 1], list.to_a
+  end
+
+  def test_list_create_from_array
+    skip
+    array = [1, 2, 3]
+    list = SimpleLinkedList.new(array)
+    assert_equal [3, 2, 1], list.to_a
+  end
+
+  def test_list_created_from_array_still_made_up_of_elements
+    skip
+    array = [1, 2, 3]
+    list = SimpleLinkedList.new(array)
+    assert_equal Element, list.pop.class
+  end
+
+  def test_list_from_array_still_acts_as_lifo
+    skip
+    array = [1, 2, 3]
+    list = SimpleLinkedList.new(array)
+    element = list.pop
+    assert_equal 3, element.datum
+  end
+
+  def test_list_in_place_reverse!
+    skip
+    first = Element.new(1)
+    second = Element.new(2)
+    third = Element.new(3)
+    list = SimpleLinkedList.new
+    list.push(first).push(second).push(third)
+
+    assert_equal [1, 2, 3], list.reverse!.to_a
+  end
+
+  def test_list_in_place_reverse_are_the_same_elements
+    skip
+    first = Element.new(1)
+    second = Element.new(2)
+    list = SimpleLinkedList.new
+    list.push(first).push(second)
+
+    list.reverse!
+
+    assert_equal first, list.pop
+    assert_equal second, list.pop
+  end
+
+  def test_list_reverse_empty_list
+    skip
+    list = SimpleLinkedList.new
+    assert_equal list, list.reverse!
+  end
+
+  def test_works_for_1_through_10
+    skip
+    list = SimpleLinkedList.new(1..10)
+    expected = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
+    assert_equal expected, list.to_a
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module.
+  #  In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -1,0 +1,48 @@
+# Space Age
+
+Given an age in seconds, calculate how old someone would be on:
+
+   - Earth: orbital period 365.25 Earth days, or 31557600 seconds
+   - Mercury: orbital period 0.2408467 Earth years
+   - Venus: orbital period 0.61519726 Earth years
+   - Mars: orbital period 1.8808158 Earth years
+   - Jupiter: orbital period 11.862615 Earth years
+   - Saturn: orbital period 29.447498 Earth years
+   - Uranus: orbital period 84.016846 Earth years
+   - Neptune: orbital period 164.79132 Earth years
+
+So if you were told someone were 1,000,000,000 seconds old, you should
+be able to say that they're 31.69 Earth-years old.
+
+If you're wondering why Pluto didn't make the cut, go watch [this
+youtube video](http://www.youtube.com/watch?v=Z_2gbGXzFbs).
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby space_age_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride space_age_test.rb
+
+
+## Source
+
+Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial. [http://pine.fm/LearnToProgram/?Chapter=01](http://pine.fm/LearnToProgram/?Chapter=01)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/space-age/space_age_test.rb
+++ b/exercises/space-age/space_age_test.rb
@@ -1,0 +1,80 @@
+require 'minitest/autorun'
+require_relative 'space_age'
+
+# Common test data version: 1.0.0 7c63e40
+class SpaceAgeTest < Minitest::Test
+  # assert_in_delta will pass if the difference
+  # between the values being compared is less
+  # than the allowed delta
+  DELTA = 0.01
+
+  def test_age_on_earth
+    # skip
+    age = SpaceAge.new(1_000_000_000)
+    assert_in_delta 31.69, age.on_earth, DELTA
+  end
+
+  def test_age_on_mercury
+    skip
+    age = SpaceAge.new(2_134_835_688)
+    assert_in_delta 280.88, age.on_mercury, DELTA
+  end
+
+  def test_age_on_venus
+    skip
+    age = SpaceAge.new(189_839_836)
+    assert_in_delta 9.78, age.on_venus, DELTA
+  end
+
+  def test_age_on_mars
+    skip
+    age = SpaceAge.new(2_329_871_239)
+    assert_in_delta 39.25, age.on_mars, DELTA
+  end
+
+  def test_age_on_jupiter
+    skip
+    age = SpaceAge.new(901_876_382)
+    assert_in_delta 2.41, age.on_jupiter, DELTA
+  end
+
+  def test_age_on_saturn
+    skip
+    age = SpaceAge.new(3_000_000_000)
+    assert_in_delta 3.23, age.on_saturn, DELTA
+  end
+
+  def test_age_on_uranus
+    skip
+    age = SpaceAge.new(3_210_123_456)
+    assert_in_delta 1.21, age.on_uranus, DELTA
+  end
+
+  def test_age_on_neptune
+    skip
+    age = SpaceAge.new(8_210_123_456)
+    assert_in_delta 1.58, age.on_neptune, DELTA
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/strain/README.md
+++ b/exercises/strain/README.md
@@ -1,0 +1,64 @@
+# Strain
+
+Implement the `keep` and `discard` operation on collections. Given a collection
+and a predicate on the collection's elements, `keep` returns a new collection
+containing those elements where the predicate is true, while `discard` returns
+a new collection containing those elements where the predicate is false.
+
+For example, given the collection of numbers:
+
+- 1, 2, 3, 4, 5
+
+And the predicate:
+
+- is the number even?
+
+Then your keep operation should produce:
+
+- 2, 4
+
+While your discard operation should produce:
+
+- 1, 3, 5
+
+Note that the union of keep and discard is all the elements.
+
+The functions may be called `keep` and `discard`, or they may need different
+names in order to not clash with existing functions or concepts in your
+language.
+
+## Restrictions
+
+Keep your hands off that filter/reject/whatchamacallit functionality
+provided by your standard library!  Solve this one yourself using other
+basic tools instead.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby strain_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride strain_test.rb
+
+
+## Source
+
+Conversation with James Edward Gray II [https://twitter.com/jeg2](https://twitter.com/jeg2)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/strain/strain_test.rb
+++ b/exercises/strain/strain_test.rb
@@ -1,0 +1,87 @@
+require 'minitest/autorun'
+require_relative 'strain'
+
+class ArrayTest < Minitest::Test
+  def test_empty_keep
+    assert_equal [], [].keep { |e| e < 10 }
+  end
+
+  def test_keep_everything
+    skip
+    assert_equal [1, 2, 3], [1, 2, 3].keep { |e| e < 10 }
+  end
+
+  def test_keep_first_and_last
+    skip
+    assert_equal [1, 3], [1, 2, 3].keep(&:odd?)
+  end
+
+  def test_keep_neither_first_nor_last
+    skip
+    assert_equal [2, 4], [1, 2, 3, 4, 5].keep(&:even?)
+  end
+
+  def test_keep_strings
+    skip
+    words = %w(apple zebra banana zombies cherimoya zelot)
+    result = words.keep { |word| word.start_with?('z') }
+    assert_equal %w(zebra zombies zelot), result
+  end
+
+  def test_keep_arrays
+    skip
+    rows = [
+      [1, 2, 3],
+      [5, 5, 5],
+      [5, 1, 2],
+      [2, 1, 2],
+      [1, 5, 2],
+      [2, 2, 1],
+      [1, 2, 5]
+    ]
+    result = rows.keep { |row| row.include?(5) }
+    assert_equal [[5, 5, 5], [5, 1, 2], [1, 5, 2], [1, 2, 5]], result
+  end
+
+  def test_empty_discard
+    skip
+    assert_equal [], [].discard { |e| e < 10 }
+  end
+
+  def test_discard_nothing
+    skip
+    assert_equal [1, 2, 3], [1, 2, 3].discard { |e| e > 10 }
+  end
+
+  def test_discard_first_and_last
+    skip
+    assert_equal [2], [1, 2, 3].discard(&:odd?)
+  end
+
+  def test_discard_neither_first_nor_last
+    skip
+    assert_equal [1, 3, 5], [1, 2, 3, 4, 5].discard(&:even?)
+  end
+
+  def test_discard_strings
+    skip
+    words = %w(apple zebra banana zombies cherimoya zelot)
+    result = words.discard { |word| word.start_with?('z') }
+    assert_equal %w(apple banana cherimoya), result
+  end
+
+  def test_discard_arrays
+    skip
+    rows = [
+      [1, 2, 3],
+      [5, 5, 5],
+      [5, 1, 2],
+      [2, 1, 2],
+      [1, 5, 2],
+      [2, 2, 1],
+      [1, 2, 5]
+    ]
+    result = rows.discard { |row| row.include?(5) }
+    assert_equal [[1, 2, 3], [2, 1, 2], [2, 2, 1]], result
+  end
+end

--- a/exercises/sum-of-multiples/README.md
+++ b/exercises/sum-of-multiples/README.md
@@ -1,0 +1,39 @@
+# Sum Of Multiples
+
+Given a number, find the sum of all the unique multiples of particular numbers up to
+but not including that number.
+
+If we list all the natural numbers below 20 that are multiples of 3 or 5,
+we get 3, 5, 6, 9, 10, 12, 15, and 18.
+
+The sum of these multiples is 78.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby sum_of_multiples_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride sum_of_multiples_test.rb
+
+
+## Source
+
+A variation on Problem 1 at Project Euler [http://projecteuler.net/problem=1](http://projecteuler.net/problem=1)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/sum-of-multiples/sum_of_multiples_test.rb
+++ b/exercises/sum-of-multiples/sum_of_multiples_test.rb
@@ -1,0 +1,92 @@
+require 'minitest/autorun'
+require_relative 'sum_of_multiples'
+
+# Common test data version: 1.1.0 df076b2
+class SumOfMultiplesTest < Minitest::Test
+  def test_multiples_of_3_or_5_up_to_1
+    # skip
+    assert_equal 0, SumOfMultiples.new(3, 5).to(1)
+  end
+
+  def test_multiples_of_3_or_5_up_to_4
+    skip
+    assert_equal 3, SumOfMultiples.new(3, 5).to(4)
+  end
+
+  def test_multiples_of_3_up_to_7
+    skip
+    assert_equal 9, SumOfMultiples.new(3).to(7)
+  end
+
+  def test_multiples_of_3_or_5_up_to_10
+    skip
+    assert_equal 23, SumOfMultiples.new(3, 5).to(10)
+  end
+
+  def test_multiples_of_3_or_5_up_to_100
+    skip
+    assert_equal 2_318, SumOfMultiples.new(3, 5).to(100)
+  end
+
+  def test_multiples_of_3_or_5_up_to_1000
+    skip
+    assert_equal 233_168, SumOfMultiples.new(3, 5).to(1000)
+  end
+
+  def test_multiples_of_7_13_or_17_up_to_20
+    skip
+    assert_equal 51, SumOfMultiples.new(7, 13, 17).to(20)
+  end
+
+  def test_multiples_of_4_or_6_up_to_15
+    skip
+    assert_equal 30, SumOfMultiples.new(4, 6).to(15)
+  end
+
+  def test_multiples_of_5_6_or_8_up_to_150
+    skip
+    assert_equal 4_419, SumOfMultiples.new(5, 6, 8).to(150)
+  end
+
+  def test_multiples_of_5_or_25_up_to_51
+    skip
+    assert_equal 275, SumOfMultiples.new(5, 25).to(51)
+  end
+
+  def test_multiples_of_43_or_47_up_to_10000
+    skip
+    assert_equal 2_203_160, SumOfMultiples.new(43, 47).to(10000)
+  end
+
+  def test_multiples_of_1_up_to_100
+    skip
+    assert_equal 4_950, SumOfMultiples.new(1).to(100)
+  end
+
+  def test_multiples_of_an_empty_list_up_to_10000
+    skip
+    assert_equal 0, SumOfMultiples.new().to(10000)
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 2, BookKeeping::VERSION
+  end
+end

--- a/exercises/tournament/README.md
+++ b/exercises/tournament/README.md
@@ -1,0 +1,91 @@
+# Tournament
+
+Tally the results of a small football competition.
+
+Based on an input file containing which team played against which and what the
+outcome was, create a file with a table like this:
+
+```text
+Team                           | MP |  W |  D |  L |  P
+Devastating Donkeys            |  3 |  2 |  1 |  0 |  7
+Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6
+Blithering Badgers             |  3 |  1 |  0 |  2 |  3
+Courageous Californians        |  3 |  0 |  1 |  2 |  1
+```
+
+What do those abbreviations mean?
+
+- MP: Matches Played
+- W: Matches Won
+- D: Matches Drawn (Tied)
+- L: Matches Lost
+- P: Points
+
+A win earns a team 3 points. A draw earns 1. A loss earns 0.
+
+The outcome should be ordered by points, descending. In case of a tie, teams are ordered alphabetically.
+
+###
+
+Input
+
+Your tallying program will receive input that looks like:
+
+```text
+Allegoric Alaskans;Blithering Badgers;win
+Devastating Donkeys;Courageous Californians;draw
+Devastating Donkeys;Allegoric Alaskans;win
+Courageous Californians;Blithering Badgers;loss
+Blithering Badgers;Devastating Donkeys;loss
+Allegoric Alaskans;Courageous Californians;win
+```
+
+The result of the match refers to the first team listed. So this line
+
+```text
+Allegoric Alaskans;Blithering Badgers;win
+```
+
+Means that the Allegoric Alaskans beat the Blithering Badgers.
+
+This line:
+
+```text
+Courageous Californians;Blithering Badgers;loss
+```
+
+Means that the Blithering Badgers beat the Courageous Californians.
+
+And this line:
+
+```text
+Devastating Donkeys;Courageous Californians;draw
+```
+
+Means that the Devastating Donkeys and Courageous Californians tied.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby tournament_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride tournament_test.rb
+
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/tournament/tournament_test.rb
+++ b/exercises/tournament/tournament_test.rb
@@ -1,0 +1,203 @@
+require 'minitest/autorun'
+require_relative 'tournament'
+
+# Common test data version: 1.3.0 f2042f1
+class TournamentTest < Minitest::Test
+  def test_just_the_header_if_no_input
+    # skip
+    input = <<-INPUT.gsub(/^ */, '')
+
+INPUT
+    actual = Tournament.tally(input)
+    expected = <<-TALLY.gsub(/^ */, '')
+Team                           | MP |  W |  D |  L |  P
+TALLY
+    assert_equal expected, actual
+  end
+
+  def test_a_win_is_three_points_a_loss_is_zero_points
+    skip
+    input = <<-INPUT.gsub(/^ */, '')
+Allegoric Alaskans;Blithering Badgers;win
+INPUT
+    actual = Tournament.tally(input)
+    expected = <<-TALLY.gsub(/^ */, '')
+Team                           | MP |  W |  D |  L |  P
+Allegoric Alaskans             |  1 |  1 |  0 |  0 |  3
+Blithering Badgers             |  1 |  0 |  0 |  1 |  0
+TALLY
+    assert_equal expected, actual
+  end
+
+  def test_a_win_can_also_be_expressed_as_a_loss
+    skip
+    input = <<-INPUT.gsub(/^ */, '')
+Blithering Badgers;Allegoric Alaskans;loss
+INPUT
+    actual = Tournament.tally(input)
+    expected = <<-TALLY.gsub(/^ */, '')
+Team                           | MP |  W |  D |  L |  P
+Allegoric Alaskans             |  1 |  1 |  0 |  0 |  3
+Blithering Badgers             |  1 |  0 |  0 |  1 |  0
+TALLY
+    assert_equal expected, actual
+  end
+
+  def test_a_different_team_can_win
+    skip
+    input = <<-INPUT.gsub(/^ */, '')
+Blithering Badgers;Allegoric Alaskans;win
+INPUT
+    actual = Tournament.tally(input)
+    expected = <<-TALLY.gsub(/^ */, '')
+Team                           | MP |  W |  D |  L |  P
+Blithering Badgers             |  1 |  1 |  0 |  0 |  3
+Allegoric Alaskans             |  1 |  0 |  0 |  1 |  0
+TALLY
+    assert_equal expected, actual
+  end
+
+  def test_a_draw_is_one_point_each
+    skip
+    input = <<-INPUT.gsub(/^ */, '')
+Allegoric Alaskans;Blithering Badgers;draw
+INPUT
+    actual = Tournament.tally(input)
+    expected = <<-TALLY.gsub(/^ */, '')
+Team                           | MP |  W |  D |  L |  P
+Allegoric Alaskans             |  1 |  0 |  1 |  0 |  1
+Blithering Badgers             |  1 |  0 |  1 |  0 |  1
+TALLY
+    assert_equal expected, actual
+  end
+
+  def test_there_can_be_more_than_one_match
+    skip
+    input = <<-INPUT.gsub(/^ */, '')
+Allegoric Alaskans;Blithering Badgers;win
+Allegoric Alaskans;Blithering Badgers;win
+INPUT
+    actual = Tournament.tally(input)
+    expected = <<-TALLY.gsub(/^ */, '')
+Team                           | MP |  W |  D |  L |  P
+Allegoric Alaskans             |  2 |  2 |  0 |  0 |  6
+Blithering Badgers             |  2 |  0 |  0 |  2 |  0
+TALLY
+    assert_equal expected, actual
+  end
+
+  def test_there_can_be_more_than_one_winner
+    skip
+    input = <<-INPUT.gsub(/^ */, '')
+Allegoric Alaskans;Blithering Badgers;loss
+Allegoric Alaskans;Blithering Badgers;win
+INPUT
+    actual = Tournament.tally(input)
+    expected = <<-TALLY.gsub(/^ */, '')
+Team                           | MP |  W |  D |  L |  P
+Allegoric Alaskans             |  2 |  1 |  0 |  1 |  3
+Blithering Badgers             |  2 |  1 |  0 |  1 |  3
+TALLY
+    assert_equal expected, actual
+  end
+
+  def test_there_can_be_more_than_two_teams
+    skip
+    input = <<-INPUT.gsub(/^ */, '')
+Allegoric Alaskans;Blithering Badgers;win
+Blithering Badgers;Courageous Californians;win
+Courageous Californians;Allegoric Alaskans;loss
+INPUT
+    actual = Tournament.tally(input)
+    expected = <<-TALLY.gsub(/^ */, '')
+Team                           | MP |  W |  D |  L |  P
+Allegoric Alaskans             |  2 |  2 |  0 |  0 |  6
+Blithering Badgers             |  2 |  1 |  0 |  1 |  3
+Courageous Californians        |  2 |  0 |  0 |  2 |  0
+TALLY
+    assert_equal expected, actual
+  end
+
+  def test_typical_input
+    skip
+    input = <<-INPUT.gsub(/^ */, '')
+Allegoric Alaskans;Blithering Badgers;win
+Devastating Donkeys;Courageous Californians;draw
+Devastating Donkeys;Allegoric Alaskans;win
+Courageous Californians;Blithering Badgers;loss
+Blithering Badgers;Devastating Donkeys;loss
+Allegoric Alaskans;Courageous Californians;win
+INPUT
+    actual = Tournament.tally(input)
+    expected = <<-TALLY.gsub(/^ */, '')
+Team                           | MP |  W |  D |  L |  P
+Devastating Donkeys            |  3 |  2 |  1 |  0 |  7
+Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6
+Blithering Badgers             |  3 |  1 |  0 |  2 |  3
+Courageous Californians        |  3 |  0 |  1 |  2 |  1
+TALLY
+    assert_equal expected, actual
+  end
+
+  def test_incomplete_competition_not_all_pairs_have_played
+    skip
+    input = <<-INPUT.gsub(/^ */, '')
+Allegoric Alaskans;Blithering Badgers;loss
+Devastating Donkeys;Allegoric Alaskans;loss
+Courageous Californians;Blithering Badgers;draw
+Allegoric Alaskans;Courageous Californians;win
+INPUT
+    actual = Tournament.tally(input)
+    expected = <<-TALLY.gsub(/^ */, '')
+Team                           | MP |  W |  D |  L |  P
+Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6
+Blithering Badgers             |  2 |  1 |  1 |  0 |  4
+Courageous Californians        |  2 |  0 |  1 |  1 |  1
+Devastating Donkeys            |  1 |  0 |  0 |  1 |  0
+TALLY
+    assert_equal expected, actual
+  end
+
+  def test_ties_broken_alphabetically
+    skip
+    input = <<-INPUT.gsub(/^ */, '')
+Courageous Californians;Devastating Donkeys;win
+Allegoric Alaskans;Blithering Badgers;win
+Devastating Donkeys;Allegoric Alaskans;loss
+Courageous Californians;Blithering Badgers;win
+Blithering Badgers;Devastating Donkeys;draw
+Allegoric Alaskans;Courageous Californians;draw
+INPUT
+    actual = Tournament.tally(input)
+    expected = <<-TALLY.gsub(/^ */, '')
+Team                           | MP |  W |  D |  L |  P
+Allegoric Alaskans             |  3 |  2 |  1 |  0 |  7
+Courageous Californians        |  3 |  2 |  1 |  0 |  7
+Blithering Badgers             |  3 |  0 |  1 |  2 |  1
+Devastating Donkeys            |  3 |  0 |  1 |  2 |  1
+TALLY
+    assert_equal expected, actual
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 3, BookKeeping::VERSION
+  end
+end

--- a/exercises/transpose/README.md
+++ b/exercises/transpose/README.md
@@ -1,0 +1,89 @@
+# Transpose
+
+Given an input text output it transposed.
+
+Roughly explained, the transpose of a matrix:
+
+```text
+ABC
+DEF
+```
+
+is given by:
+
+```text
+AD
+BE
+CF
+```
+
+Rows become columns and columns become rows. See <https://en.wikipedia.org/wiki/Transpose>.
+
+If the input has rows of different lengths, this is to be solved as follows:
+
+- Pad to the left with spaces.
+- Don't pad to the right.
+
+Therefore, transposing this matrix:
+
+```text
+ABC
+DE
+```
+
+results in:
+
+```text
+AD
+BE
+C
+```
+
+And transposing:
+
+```text
+AB
+DEF
+```
+
+results in:
+
+```text
+AD
+BE
+ F
+```
+
+In general, all characters from the input should also be present in the transposed output.
+That means that if a column in the input text contains only spaces on its bottom-most row(s),
+the corresponding output row should contain the spaces in its right-most column(s).
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby transpose_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride transpose_test.rb
+
+
+## Source
+
+Reddit r/dailyprogrammer challenge #270 [Easy]. [https://www.reddit.com/r/dailyprogrammer/comments/4msu2x/challenge_270_easy_transpose_the_input_text](https://www.reddit.com/r/dailyprogrammer/comments/4msu2x/challenge_270_easy_transpose_the_input_text)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/transpose/transpose_test.rb
+++ b/exercises/transpose/transpose_test.rb
@@ -1,0 +1,300 @@
+require 'minitest/autorun'
+require_relative 'transpose'
+
+# Common test data version: 1.0.0 6dba022
+class TransposeTest < Minitest::Test
+  def test_empty_string
+    # skip
+    input = <<-INPUT.gsub(/^ {6}/, '')
+
+INPUT
+    actual = Transpose.transpose(input)
+    expected = <<-EXPECTED.gsub(/^ {6}/, '')
+
+EXPECTED
+    assert_equal expected.strip, actual
+  end
+
+  def test_two_characters_in_a_row
+    skip
+    input = <<-INPUT.gsub(/^ {6}/, '')
+      A1
+INPUT
+    actual = Transpose.transpose(input)
+    expected = <<-EXPECTED.gsub(/^ {6}/, '')
+      A
+      1
+EXPECTED
+    assert_equal expected.strip, actual
+  end
+
+  def test_two_characters_in_a_column
+    skip
+    input = <<-INPUT.gsub(/^ {6}/, '')
+      A
+      1
+INPUT
+    actual = Transpose.transpose(input)
+    expected = <<-EXPECTED.gsub(/^ {6}/, '')
+      A1
+EXPECTED
+    assert_equal expected.strip, actual
+  end
+
+  def test_simple
+    skip
+    input = <<-INPUT.gsub(/^ {6}/, '')
+      ABC
+      123
+INPUT
+    actual = Transpose.transpose(input)
+    expected = <<-EXPECTED.gsub(/^ {6}/, '')
+      A1
+      B2
+      C3
+EXPECTED
+    assert_equal expected.strip, actual
+  end
+
+  def test_single_line
+    skip
+    input = <<-INPUT.gsub(/^ {6}/, '')
+      Single line.
+INPUT
+    actual = Transpose.transpose(input)
+    expected = <<-EXPECTED.gsub(/^ {6}/, '')
+      S
+      i
+      n
+      g
+      l
+      e
+       
+      l
+      i
+      n
+      e
+      .
+EXPECTED
+    assert_equal expected.strip, actual
+  end
+
+  def test_first_line_longer_than_second_line
+    skip
+    input = <<-INPUT.gsub(/^ {6}/, '')
+      The fourth line.
+      The fifth line.
+INPUT
+    actual = Transpose.transpose(input)
+    expected = <<-EXPECTED.gsub(/^ {6}/, '')
+      TT
+      hh
+      ee
+        
+      ff
+      oi
+      uf
+      rt
+      th
+      h 
+       l
+      li
+      in
+      ne
+      e.
+      .
+EXPECTED
+    assert_equal expected.strip, actual
+  end
+
+  def test_second_line_longer_than_first_line
+    skip
+    input = <<-INPUT.gsub(/^ {6}/, '')
+      The first line.
+      The second line.
+INPUT
+    actual = Transpose.transpose(input)
+    expected = <<-EXPECTED.gsub(/^ {6}/, '')
+      TT
+      hh
+      ee
+        
+      fs
+      ie
+      rc
+      so
+      tn
+       d
+      l 
+      il
+      ni
+      en
+      .e
+       .
+EXPECTED
+    assert_equal expected.strip, actual
+  end
+
+  def test_square
+    skip
+    input = <<-INPUT.gsub(/^ {6}/, '')
+      HEART
+      EMBER
+      ABUSE
+      RESIN
+      TREND
+INPUT
+    actual = Transpose.transpose(input)
+    expected = <<-EXPECTED.gsub(/^ {6}/, '')
+      HEART
+      EMBER
+      ABUSE
+      RESIN
+      TREND
+EXPECTED
+    assert_equal expected.strip, actual
+  end
+
+  def test_rectangle
+    skip
+    input = <<-INPUT.gsub(/^ {6}/, '')
+      FRACTURE
+      OUTLINED
+      BLOOMING
+      SEPTETTE
+INPUT
+    actual = Transpose.transpose(input)
+    expected = <<-EXPECTED.gsub(/^ {6}/, '')
+      FOBS
+      RULE
+      ATOP
+      CLOT
+      TIME
+      UNIT
+      RENT
+      EDGE
+EXPECTED
+    assert_equal expected.strip, actual
+  end
+
+  def test_triangle
+    skip
+    input = <<-INPUT.gsub(/^ {6}/, '')
+      T
+      EE
+      AAA
+      SSSS
+      EEEEE
+      RRRRRR
+INPUT
+    actual = Transpose.transpose(input)
+    expected = <<-EXPECTED.gsub(/^ {6}/, '')
+      TEASER
+       EASER
+        ASER
+         SER
+          ER
+           R
+EXPECTED
+    assert_equal expected.strip, actual
+  end
+
+  def test_many_lines
+    skip
+    input = <<-INPUT.gsub(/^ {6}/, '')
+      Chor. Two households, both alike in dignity,
+      In fair Verona, where we lay our scene,
+      From ancient grudge break to new mutiny,
+      Where civil blood makes civil hands unclean.
+      From forth the fatal loins of these two foes
+      A pair of star-cross'd lovers take their life;
+      Whose misadventur'd piteous overthrows
+      Doth with their death bury their parents' strife.
+      The fearful passage of their death-mark'd love,
+      And the continuance of their parents' rage,
+      Which, but their children's end, naught could remove,
+      Is now the two hours' traffic of our stage;
+      The which if you with patient ears attend,
+      What here shall miss, our toil shall strive to mend.
+INPUT
+    actual = Transpose.transpose(input)
+    expected = <<-EXPECTED.gsub(/^ {6}/, '')
+      CIFWFAWDTAWITW
+      hnrhr hohnhshh
+      o oeopotedi ea
+      rfmrmash  cn t
+      .a e ie fthow 
+       ia fr weh,whh
+      Trnco miae  ie
+      w ciroitr btcr
+      oVivtfshfcuhhe
+       eeih a uote  
+      hrnl sdtln  is
+      oot ttvh tttfh
+      un bhaeepihw a
+      saglernianeoyl
+      e,ro -trsui ol
+      h uofcu sarhu 
+      owddarrdan o m
+      lhg to'egccuwi
+      deemasdaeehris
+      sr als t  ists
+      ,ebk 'phool'h,
+        reldi ffd   
+      bweso tb  rtpo
+      oea ileutterau
+      t kcnoorhhnatr
+      hl isvuyee'fi 
+       atv es iisfet
+      ayoior trr ino
+      l  lfsoh  ecti
+      ion   vedpn  l
+      kuehtteieadoe 
+      erwaharrar,fas
+         nekt te  rh
+      ismdsehphnnosa
+      ncuse ra-tau l
+       et  tormsural
+      dniuthwea'g t 
+      iennwesnr hsts
+      g,ycoi tkrttet
+      n ,l r s'a anr
+      i  ef  'dgcgdi
+      t  aol   eoe,v
+      y  nei sl,u; e
+      ,  .sf to l   
+           e rv d  t
+           ; ie    o
+             f, r   
+             e  e  m
+             .  m  e
+                o  n
+                v  d
+                e  .
+                ,
+EXPECTED
+    assert_equal expected.strip, actual
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -1,0 +1,53 @@
+# Triangle
+
+Determine if a triangle is equilateral, isosceles, or scalene.
+
+An _equilateral_ triangle has all three sides the same length.
+
+An _isosceles_ triangle has at least two sides the same length. (It is sometimes
+specified as having exactly two sides the same length, but for the purposes of
+this exercise we'll say at least two.)
+
+A _scalene_ triangle has all sides of different lengths.
+
+## Note
+
+For a shape to be a triangle at all, all sides have to be of length > 0, and
+the sum of the lengths of any two sides must be greater than or equal to the
+length of the third side. See [Triangle Inequality](https://en.wikipedia.org/wiki/Triangle_inequality).
+
+## Dig Deeper
+
+The case where the sum of the lengths of two sides _equals_ that of the
+third is known as a _degenerate_ triangle - it has zero area and looks like
+a single line. Feel free to add your own code/tests to check for degenerate triangles.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby triangle_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride triangle_test.rb
+
+
+## Source
+
+The Ruby Koans triangle project, parts 1 & 2 [http://rubykoans.com](http://rubykoans.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/triangle/triangle_test.rb
+++ b/exercises/triangle/triangle_test.rb
@@ -1,0 +1,129 @@
+require 'minitest/autorun'
+require_relative 'triangle'
+
+# Common test data version: 1.0.0 8acd78c
+class TriangleTest < Minitest::Test
+  def test_triangle_is_equilateral_if_all_sides_are_equal
+    # skip
+    triangle = Triangle.new([2, 2, 2])
+    assert triangle.equilateral?, "Expected 'true', triangle [2, 2, 2] is equilateral."
+  end
+
+  def test_triangle_is_not_equilateral_if_any_side_is_unequal
+    skip
+    triangle = Triangle.new([2, 3, 2])
+    refute triangle.equilateral?, "Expected 'false', triangle [2, 3, 2] is not equilateral."
+  end
+
+  def test_triangle_is_not_equilateral_if_no_sides_are_equal
+    skip
+    triangle = Triangle.new([5, 4, 6])
+    refute triangle.equilateral?, "Expected 'false', triangle [5, 4, 6] is not equilateral."
+  end
+
+  def test_all_zero_sides_are_illegal_so_the_triangle_is_not_equilateral
+    skip
+    triangle = Triangle.new([0, 0, 0])
+    refute triangle.equilateral?, "Expected 'false', triangle [0, 0, 0] is not equilateral."
+  end
+
+  def test_equilateral_triangle_sides_may_be_floats
+    skip
+    triangle = Triangle.new([0.5, 0.5, 0.5])
+    assert triangle.equilateral?, "Expected 'true', triangle [0.5, 0.5, 0.5] is equilateral."
+  end
+
+  def test_triangle_is_isosceles_if_last_two_sides_are_equal
+    skip
+    triangle = Triangle.new([3, 4, 4])
+    assert triangle.isosceles?, "Expected 'true', triangle [3, 4, 4] is isosceles."
+  end
+
+  def test_triangle_is_isosceles_if_first_two_sides_are_equal
+    skip
+    triangle = Triangle.new([4, 4, 3])
+    assert triangle.isosceles?, "Expected 'true', triangle [4, 4, 3] is isosceles."
+  end
+
+  def test_triangle_is_isosceles_if_first_and_last_sides_are_equal
+    skip
+    triangle = Triangle.new([4, 3, 4])
+    assert triangle.isosceles?, "Expected 'true', triangle [4, 3, 4] is isosceles."
+  end
+
+  def test_equilateral_triangles_are_also_isosceles
+    skip
+    triangle = Triangle.new([4, 4, 4])
+    assert triangle.isosceles?, "Expected 'true', triangle [4, 4, 4] is isosceles."
+  end
+
+  def test_triangle_is_not_isosceles_if_no_sides_are_equal
+    skip
+    triangle = Triangle.new([2, 3, 4])
+    refute triangle.isosceles?, "Expected 'false', triangle [2, 3, 4] is not isosceles."
+  end
+
+  def test_sides_that_violate_triangle_inequality_are_not_isosceles_even_if_two_are_equal
+    skip
+    triangle = Triangle.new([1, 1, 3])
+    refute triangle.isosceles?, "Expected 'false', triangle [1, 1, 3] is not isosceles."
+  end
+
+  def test_isosceles_triangle_sides_may_be_floats
+    skip
+    triangle = Triangle.new([0.5, 0.4, 0.5])
+    assert triangle.isosceles?, "Expected 'true', triangle [0.5, 0.4, 0.5] is isosceles."
+  end
+
+  def test_triangle_is_scalene_if_no_sides_are_equal
+    skip
+    triangle = Triangle.new([5, 4, 6])
+    assert triangle.scalene?, "Expected 'true', triangle [5, 4, 6] is scalene."
+  end
+
+  def test_triangle_is_not_scalene_if_all_sides_are_equal
+    skip
+    triangle = Triangle.new([4, 4, 4])
+    refute triangle.scalene?, "Expected 'false', triangle [4, 4, 4] is not scalene."
+  end
+
+  def test_triangle_is_not_scalene_if_two_sides_are_equal
+    skip
+    triangle = Triangle.new([4, 4, 3])
+    refute triangle.scalene?, "Expected 'false', triangle [4, 4, 3] is not scalene."
+  end
+
+  def test_sides_that_violate_triangle_inequality_are_not_scalene_even_if_they_are_all_different
+    skip
+    triangle = Triangle.new([7, 3, 2])
+    refute triangle.scalene?, "Expected 'false', triangle [7, 3, 2] is not scalene."
+  end
+
+  def test_scalene_triangle_sides_may_be_floats
+    skip
+    triangle = Triangle.new([0.5, 0.4, 0.6])
+    assert triangle.scalene?, "Expected 'true', triangle [0.5, 0.4, 0.6] is scalene."
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/trinary/README.md
+++ b/exercises/trinary/README.md
@@ -1,0 +1,52 @@
+# Trinary
+
+Convert a trinary number, represented as a string (e.g. '102012'), to its
+decimal equivalent using first principles.
+
+The program should consider strings specifying an invalid trinary as the
+value 0.
+
+Trinary numbers contain three symbols: 0, 1, and 2.
+
+The last place in a trinary number is the 1's place. The second to last
+is the 3's place, the third to last is the 9's place, etc.
+
+```shell
+# "102012"
+    1       0       2       0       1       2    # the number
+1*3^5 + 0*3^4 + 2*3^3 + 0*3^2 + 1*3^1 + 2*3^0    # the value
+  243 +     0 +    54 +     0 +     3 +     2 =  302
+```
+
+If your language provides a method in the standard library to perform the
+conversion, pretend it doesn't exist and implement it yourself.
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby trinary_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride trinary_test.rb
+
+
+## Source
+
+All of Computer Science [http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-](http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/trinary/trinary_test.rb
+++ b/exercises/trinary/trinary_test.rb
@@ -1,0 +1,83 @@
+require 'minitest/autorun'
+require_relative 'trinary'
+
+class TrinaryTest < Minitest::Test
+  def test_trinary_1_is_decimal_1
+    assert_equal 1, Trinary.new('1').to_decimal
+  end
+
+  def test_trinary_2_is_decimal_2
+    skip
+    assert_equal 2, Trinary.new('2').to_decimal
+  end
+
+  def test_trinary_10_is_decimal_3
+    skip
+    assert_equal 3, Trinary.new('10').to_decimal
+  end
+
+  def test_trinary_11_is_decimal_4
+    skip
+    assert_equal 4, Trinary.new('11').to_decimal
+  end
+
+  def test_trinary_100_is_decimal_9
+    skip
+    assert_equal 9, Trinary.new('100').to_decimal
+  end
+
+  def test_trinary_112_is_decimal_14
+    skip
+    assert_equal 14, Trinary.new('112').to_decimal
+  end
+
+  def test_trinary_222_is_26
+    skip
+    assert_equal 26, Trinary.new('222').to_decimal
+  end
+
+  def test_trinary_1122000120_is_32091
+    skip
+    assert_equal 32_091, Trinary.new('1122000120').to_decimal
+  end
+
+  def test_invalid_trinary_is_decimal_0
+    skip
+    assert_equal 0, Trinary.new('carrot').to_decimal
+  end
+
+  def test_invalid_trinary_with_digits_is_decimal_0
+    skip
+    assert_equal 0, Trinary.new('0a1b2c').to_decimal
+  end
+
+  def test_invalid_trinary_with_multiline_string
+    skip
+    assert_equal 0, Trinary.new("Invalid\n201\nString").to_decimal
+  end
+
+  def test_number_out_of_range
+    skip
+    assert_equal 0, Trinary.new('4').to_decimal
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module.
+  #  In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.htm
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/twelve-days/README.md
+++ b/exercises/twelve-days/README.md
@@ -1,0 +1,59 @@
+# Twelve Days
+
+Output the lyrics to 'The Twelve Days of Christmas'.
+
+```text
+On the first day of Christmas my true love gave to me, a Partridge in a Pear Tree.
+
+On the second day of Christmas my true love gave to me, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the third day of Christmas my true love gave to me, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the fourth day of Christmas my true love gave to me, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the fifth day of Christmas my true love gave to me, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the sixth day of Christmas my true love gave to me, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the seventh day of Christmas my true love gave to me, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the eighth day of Christmas my true love gave to me, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the ninth day of Christmas my true love gave to me, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the tenth day of Christmas my true love gave to me, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the eleventh day of Christmas my true love gave to me, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the twelfth day of Christmas my true love gave to me, twelve Drummers Drumming, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+```
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby twelve_days_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride twelve_days_test.rb
+
+
+## Source
+
+Wikipedia [http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song)](http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song))
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/twelve-days/song.txt
+++ b/exercises/twelve-days/song.txt
@@ -1,0 +1,23 @@
+On the first day of Christmas my true love gave to me, a Partridge in a Pear Tree.
+
+On the second day of Christmas my true love gave to me, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the third day of Christmas my true love gave to me, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the fourth day of Christmas my true love gave to me, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the fifth day of Christmas my true love gave to me, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the sixth day of Christmas my true love gave to me, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the seventh day of Christmas my true love gave to me, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the eighth day of Christmas my true love gave to me, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the ninth day of Christmas my true love gave to me, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the tenth day of Christmas my true love gave to me, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the eleventh day of Christmas my true love gave to me, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+
+On the twelfth day of Christmas my true love gave to me, twelve Drummers Drumming, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.

--- a/exercises/twelve-days/twelve_days_test.rb
+++ b/exercises/twelve-days/twelve_days_test.rb
@@ -1,0 +1,30 @@
+require 'minitest/autorun'
+require_relative 'twelve_days'
+
+class TwelveDaysTest < Minitest::Test
+  # This test is an acceptance test.
+  #
+  # If you find it difficult to work the problem with so much
+  # output, go ahead and add a `skip`, and write whatever
+  # unit tests will help you. Then unskip it again
+  # to make sure you got it right.
+  # There's no need to submit the tests you write, unless you
+  # specifically want feedback on them.
+  def test_the_whole_song
+    song_file = File.expand_path('../song.txt', __FILE__)
+    expected = IO.read(song_file)
+    assert_equal expected, TwelveDays.song
+  end
+
+  # Problems in exercism evolve over time,
+  # as we find better ways to ask questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of TwelveDays.
+  # If you're curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+  def test_version
+    assert_equal 2, BookKeeping::VERSION
+  end
+end

--- a/exercises/two-bucket/README.md
+++ b/exercises/two-bucket/README.md
@@ -1,0 +1,60 @@
+# Two Bucket
+
+Given two buckets of different size, demonstrate how to measure an exact number of liters by strategically transferring liters of fluid between the buckets.
+
+Since this mathematical problem is fairly subject to interpretation / individual approach, the tests have been written specifically to expect one overarching solution.
+
+To help, the tests provide you with which bucket to fill first. That means, when starting with the larger bucket full, you are NOT allowed at any point to have the smaller bucket full and the larger bucket empty (aka, the opposite starting point); that would defeat the purpose of comparing both approaches!
+
+Your program will take as input:
+- the size of bucket one
+- the size of bucket two
+- the desired number of liters to reach
+- which bucket to fill first, either bucket one or bucket two
+
+Your program should determine:
+- the total number of "moves" it should take to reach the desired number of liters, including the first fill
+- which bucket should end up with the desired number of liters (let's say this is bucket A) - either bucket one or bucket two
+- how many liters are left in the other bucket (bucket B)
+
+Note: any time a change is made to either or both buckets counts as one (1) move.
+
+Example:
+Bucket one can hold up to 7 liters, and bucket two can hold up to 11 liters. Let's say bucket one, at a given step, is holding 7 liters, and bucket two is holding 8 liters (7,8). If you empty bucket one and make no change to bucket two, leaving you with 0 liters and 8 liters respectively (0,8), that counts as one "move". Instead, if you had poured from bucket one into bucket two until bucket two was full, leaving you with 4 liters in bucket one and 11 liters in bucket two (4,11), that would count as only one "move" as well.
+
+To conclude, the only valid moves are:
+- pouring from one bucket to another
+- emptying one bucket and doing nothing to the other
+- filling one bucket and doing nothing to the other
+
+Written with <3 at [Fullstack Academy](http://www.fullstackacademy.com/) by [Lindsay](http://lindsaylevine.com).
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby two_bucket_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride two_bucket_test.rb
+
+
+## Source
+
+Water Pouring Problem [http://demonstrations.wolfram.com/WaterPouringProblem/](http://demonstrations.wolfram.com/WaterPouringProblem/)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/two-bucket/two_bucket_test.rb
+++ b/exercises/two-bucket/two_bucket_test.rb
@@ -1,0 +1,75 @@
+require 'minitest/autorun'
+require_relative 'two_bucket'
+
+# Common test data version: 1.2.0 8aa11e8
+class TwoBucketTest < Minitest::Test
+  def test_bucket_one_size_3_bucket_two_size_5_goal_1_start_with_bucket_one
+    # skip
+    two_bucket = TwoBucket.new(3, 5, 1, 'one')
+    assert_equal 4, two_bucket.moves
+    assert_equal 'one', two_bucket.goal_bucket
+    assert_equal 5, two_bucket.other_bucket
+  end
+
+  def test_bucket_one_size_3_bucket_two_size_5_goal_1_start_with_bucket_two
+    skip
+    two_bucket = TwoBucket.new(3, 5, 1, 'two')
+    assert_equal 8, two_bucket.moves
+    assert_equal 'two', two_bucket.goal_bucket
+    assert_equal 3, two_bucket.other_bucket
+  end
+
+  def test_bucket_one_size_7_bucket_two_size_11_goal_2_start_with_bucket_one
+    skip
+    two_bucket = TwoBucket.new(7, 11, 2, 'one')
+    assert_equal 14, two_bucket.moves
+    assert_equal 'one', two_bucket.goal_bucket
+    assert_equal 11, two_bucket.other_bucket
+  end
+
+  def test_bucket_one_size_7_bucket_two_size_11_goal_2_start_with_bucket_two
+    skip
+    two_bucket = TwoBucket.new(7, 11, 2, 'two')
+    assert_equal 18, two_bucket.moves
+    assert_equal 'two', two_bucket.goal_bucket
+    assert_equal 7, two_bucket.other_bucket
+  end
+
+  def test_bucket_one_size_1_bucket_two_size_3_goal_3_start_with_bucket_two
+    skip
+    two_bucket = TwoBucket.new(1, 3, 3, 'two')
+    assert_equal 1, two_bucket.moves
+    assert_equal 'two', two_bucket.goal_bucket
+    assert_equal 0, two_bucket.other_bucket
+  end
+
+  def test_bucket_one_size_2_bucket_two_size_3_goal_3_start_with_bucket_one
+    skip
+    two_bucket = TwoBucket.new(2, 3, 3, 'one')
+    assert_equal 2, two_bucket.moves
+    assert_equal 'two', two_bucket.goal_bucket
+    assert_equal 2, two_bucket.other_bucket
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 4, BookKeeping::VERSION
+  end
+end

--- a/exercises/two-fer/README.md
+++ b/exercises/two-fer/README.md
@@ -1,0 +1,43 @@
+# Two Fer
+
+`Two-fer` or `2-fer` is short for two for one. One for you and one for me.
+
+```text
+"One for X, one for me."
+```
+
+When X is a name or "you".
+
+If the given name is "Alice", the result should be "One for Alice, one for me."
+If no name is given, the result should be "One for you, one for me."
+
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby two_fer_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride two_fer_test.rb
+
+
+## Source
+
+This is an exercise to introduce users to basic programming constructs, just after Hello World. [https://en.wikipedia.org/wiki/Two-fer](https://en.wikipedia.org/wiki/Two-fer)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/two-fer/two_fer_test.rb
+++ b/exercises/two-fer/two_fer_test.rb
@@ -1,0 +1,42 @@
+require 'minitest/autorun'
+require_relative 'two_fer'
+
+# Common test data version: 1.1.0 c080bdf
+class TwoFerTest < Minitest::Test
+  def test_no_name_given
+    # skip
+    assert_equal "One for you, one for me.", TwoFer.two_fer
+  end
+
+  def test_a_name_given
+    skip
+    assert_equal "One for Alice, one for me.", TwoFer.two_fer("Alice")
+  end
+
+  def test_another_name_given
+    skip
+    assert_equal "One for Bob, one for me.", TwoFer.two_fer("Bob")
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -1,0 +1,42 @@
+# Word Count
+
+Given a phrase, count the occurrences of each word in that phrase.
+
+For example for the input `"olly olly in come free"`
+
+```text
+olly: 2
+in: 1
+come: 1
+free: 1
+```
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby word_count_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride word_count_test.rb
+
+
+## Source
+
+This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/word-count/word_count_test.rb
+++ b/exercises/word-count/word_count_test.rb
@@ -1,0 +1,97 @@
+require 'minitest/autorun'
+require_relative 'word_count'
+
+# Common test data version: 1.0.0 cd26d49
+class WordCountTest < Minitest::Test
+  def test_count_one_word
+    # skip
+    phrase = Phrase.new("word")
+    counts = {"word"=>1}
+    assert_equal counts, phrase.word_count
+  end
+
+  def test_count_one_of_each_word
+    skip
+    phrase = Phrase.new("one of each")
+    counts = {"one"=>1, "of"=>1, "each"=>1}
+    assert_equal counts, phrase.word_count
+  end
+
+  def test_multiple_occurrences_of_a_word
+    skip
+    phrase = Phrase.new("one fish two fish red fish blue fish")
+    counts = {"one"=>1, "fish"=>4, "two"=>1, "red"=>1, "blue"=>1}
+    assert_equal counts, phrase.word_count
+  end
+
+  def test_handles_cramped_lists
+    skip
+    phrase = Phrase.new("one,two,three")
+    counts = {"one"=>1, "two"=>1, "three"=>1}
+    assert_equal counts, phrase.word_count
+  end
+
+  def test_handles_expanded_lists
+    skip
+    phrase = Phrase.new("one,\ntwo,\nthree")
+    counts = {"one"=>1, "two"=>1, "three"=>1}
+    assert_equal counts, phrase.word_count
+  end
+
+  def test_ignore_punctuation
+    skip
+    phrase = Phrase.new("car: carpet as java: javascript!!&@$%^&")
+    counts = {"car"=>1, "carpet"=>1, "as"=>1, "java"=>1, "javascript"=>1}
+    assert_equal counts, phrase.word_count
+  end
+
+  def test_include_numbers
+    skip
+    phrase = Phrase.new("testing, 1, 2 testing")
+    counts = {"testing"=>2, "1"=>1, "2"=>1}
+    assert_equal counts, phrase.word_count
+  end
+
+  def test_normalize_case
+    skip
+    phrase = Phrase.new("go Go GO Stop stop")
+    counts = {"go"=>3, "stop"=>2}
+    assert_equal counts, phrase.word_count
+  end
+
+  def test_with_apostrophes
+    skip
+    phrase = Phrase.new("First: don't laugh. Then: don't cry.")
+    counts = {"first"=>1, "don't"=>2, "laugh"=>1, "then"=>1, "cry"=>1}
+    assert_equal counts, phrase.word_count
+  end
+
+  def test_with_quotations
+    skip
+    phrase = Phrase.new("Joe can't tell between 'large' and large.")
+    counts = {"joe"=>1, "can't"=>1, "tell"=>1, "between"=>1, "large"=>2, "and"=>1}
+    assert_equal counts, phrase.word_count
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+end

--- a/exercises/wordy/README.md
+++ b/exercises/wordy/README.md
@@ -1,0 +1,82 @@
+# Wordy
+
+Parse and evaluate simple math word problems returning the answer as an integer.
+
+## Iteration 1 — Addition
+
+Add two numbers together.
+
+> What is 5 plus 13?
+
+Evaluates to 18.
+
+Handle large numbers and negative numbers.
+
+## Iteration 2 — Subtraction, Multiplication and Division
+
+Now, perform the other three operations.
+
+> What is 7 minus 5?
+
+2
+
+> What is 6 multiplied by 4?
+
+24
+
+> What is 25 divided by 5?
+
+5
+
+## Iteration 3 — Multiple Operations
+
+Handle a set of operations, in sequence.
+
+Since these are verbal word problems, evaluate the expression from
+left-to-right, _ignoring the typical order of operations._
+
+> What is 5 plus 13 plus 6?
+
+24
+
+> What is 3 plus 2 multiplied by 3?
+
+15  (i.e. not 9)
+
+## Bonus — Exponentials
+
+If you'd like, handle exponentials.
+
+> What is 2 raised to the 5th power?
+
+32
+
+* * * *
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/ruby).
+
+For running the tests provided, you will need the Minitest gem. Open a
+terminal window and run the following command to install minitest:
+
+    gem install minitest
+
+If you would like color output, you can `require 'minitest/pride'` in
+the test file, or note the alternative instruction, below, for running
+the test file.
+
+Run the tests from the exercise directory using the following command:
+
+    ruby wordy_test.rb
+
+To include color from the command line:
+
+    ruby -r minitest/pride wordy_test.rb
+
+
+## Source
+
+Inspired by one of the generated questions in the Extreme Startup game. [https://github.com/rchatley/extreme_startup](https://github.com/rchatley/extreme_startup)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/wordy/wordy_test.rb
+++ b/exercises/wordy/wordy_test.rb
@@ -1,0 +1,129 @@
+require 'minitest/autorun'
+require_relative 'wordy'
+
+# Common test data version: 1.0.0 5b8ad58
+class WordyTest < Minitest::Test
+  def test_addition
+    # skip
+    question = 'What is 1 plus 1?'
+    assert_equal(2, WordProblem.new(question).answer)
+  end
+
+  def test_more_addition
+    skip
+    question = 'What is 53 plus 2?'
+    assert_equal(55, WordProblem.new(question).answer)
+  end
+
+  def test_addition_with_negative_numbers
+    skip
+    question = 'What is -1 plus -10?'
+    assert_equal(-11, WordProblem.new(question).answer)
+  end
+
+  def test_large_addition
+    skip
+    question = 'What is 123 plus 45678?'
+    assert_equal(45801, WordProblem.new(question).answer)
+  end
+
+  def test_subtraction
+    skip
+    question = 'What is 4 minus -12?'
+    assert_equal(16, WordProblem.new(question).answer)
+  end
+
+  def test_multiplication
+    skip
+    question = 'What is -3 multiplied by 25?'
+    assert_equal(-75, WordProblem.new(question).answer)
+  end
+
+  def test_division
+    skip
+    question = 'What is 33 divided by -3?'
+    assert_equal(-11, WordProblem.new(question).answer)
+  end
+
+  def test_multiple_additions
+    skip
+    question = 'What is 1 plus 1 plus 1?'
+    assert_equal(3, WordProblem.new(question).answer)
+  end
+
+  def test_addition_and_subtraction
+    skip
+    question = 'What is 1 plus 5 minus -2?'
+    assert_equal(8, WordProblem.new(question).answer)
+  end
+
+  def test_multiple_subtraction
+    skip
+    question = 'What is 20 minus 4 minus 13?'
+    assert_equal(3, WordProblem.new(question).answer)
+  end
+
+  def test_subtraction_then_addition
+    skip
+    question = 'What is 17 minus 6 plus 3?'
+    assert_equal(14, WordProblem.new(question).answer)
+  end
+
+  def test_multiple_multiplication
+    skip
+    question = 'What is 2 multiplied by -2 multiplied by 3?'
+    assert_equal(-12, WordProblem.new(question).answer)
+  end
+
+  def test_addition_and_multiplication
+    skip
+    question = 'What is -3 plus 7 multiplied by -2?'
+    answer = WordProblem.new(question).answer
+    message = "You should ignore order of precedence. -3 + 7 * -2 = -8, not #{answer}"
+    assert_equal(-8, answer, message)
+  end
+
+  def test_multiple_division
+    skip
+    question = 'What is -12 divided by 2 divided by -3?'
+    assert_equal(2, WordProblem.new(question).answer)
+  end
+
+  def test_unknown_operation
+    skip
+    question = 'What is 52 cubed?'
+    assert_raises ArgumentError do
+      WordProblem.new(question).answer
+    end
+  end
+
+  def test_non_math_question
+    skip
+    question = 'Who is the President of the United States?'
+    assert_raises ArgumentError do
+      WordProblem.new(question).answer
+    end
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
+end


### PR DESCRIPTION
These are all the ruby exercises from the Exercism project
These are all minitest tests.

Todo: 

Update the test runner to run the minitest tests.

Questions: 
Should we edit the README files to remove the Exercism specific text?
(It should not be too difficult to re-generate them without it.)

Can we put all the exercises at once into the docker container and then only score specific "active" exercises. (So you don't need to re-provision the docker containers for every problem.)

